### PR TITLE
feat(infra): add KMS + Secrets Manager stack (INFRA-6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .env
 .DS_Store
 node_modules/
+
+.mcp*
+.vscode/
+
+*.docx

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,20 @@
 SHELL := /bin/bash
 
 STAGE ?=
-STACK_NAME := solo-vault-shared-network-$(STAGE)
+STACK ?= shared-network
+STACK_NAME := solo-vault-$(STACK)-$(STAGE)
 
-.PHONY: help install deploy destroy ensure-stage
+.PHONY: help install deploy destroy ensure-args
 
 help:
 	@echo "Usage:"
 	@echo "  make install"
-	@echo "  make deploy STAGE=dev|staging"
-	@echo "  make destroy STAGE=dev|staging"
+	@echo "  make deploy  STAGE=dev|staging [STACK=shared-network|secrets]"
+	@echo "  make destroy STAGE=dev|staging [STACK=shared-network|secrets]"
+	@echo ""
+	@echo "STACK defaults to shared-network."
 
-ensure-stage:
+ensure-args:
 	@if [ -z "$(STAGE)" ]; then \
 		echo "Error: STAGE is required. Use STAGE=dev or STAGE=staging."; \
 		exit 1; \
@@ -20,12 +23,16 @@ ensure-stage:
 		echo "Error: invalid STAGE '$(STAGE)'. Allowed values: dev, staging."; \
 		exit 1; \
 	fi
+	@if [ "$(STACK)" != "shared-network" ] && [ "$(STACK)" != "secrets" ]; then \
+		echo "Error: invalid STACK '$(STACK)'. Allowed values: shared-network, secrets."; \
+		exit 1; \
+	fi
 
 install:
 	npm install
 
-deploy: ensure-stage
-	npm run iac -- --env $(STAGE)
+deploy: ensure-args
+	npm run iac -- --env $(STAGE) --stack $(STACK)
 
-destroy: ensure-stage
-	npm run iac -- --action destroy --env $(STAGE) --confirm-destroy $(STACK_NAME)
+destroy: ensure-args
+	npm run iac -- --action destroy --env $(STAGE) --stack $(STACK) --confirm-destroy $(STACK_NAME)

--- a/deploy.md
+++ b/deploy.md
@@ -2,22 +2,32 @@
 
 This guide covers what the current infrastructure bootstrap deploys and how to deploy or destroy it safely.
 
-## Scope of current deployment
+## Stacks
 
-Current stack provisions the **shared network baseline** only:
+The deploy script supports multiple CloudFormation stacks via the `--stack` flag.
+Each stack has a YAML template under `infra/cloudformation/` and a config entry
+under `stacks.<name>` in `infra/config/{env}.json`.
 
-- 1 VPC
-- 2 private subnets (AZ-a, AZ-b)
-- 1 Lambda security group
-- 1 RDS security group
-- RDS SG inbound rule: PostgreSQL `5432` allowed only from Lambda SG
+| Stack            | Template                                      | What it creates                                                                                                  |
+|------------------|-----------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| `shared-network` | `infra/cloudformation/shared-network.yml`     | 1 VPC, 2 private subnets (AZ-a, AZ-b), Lambda SG, RDS SG (5432 inbound from Lambda SG only)                      |
+| `secrets`        | `infra/cloudformation/secrets.yml`            | 2 customer-managed KMS keys (S3, RDS) + aliases; 3 Secrets Manager secrets (db-credentials, embedding-api-key, cloudfront-key-pair) |
 
-No API Gateway, Lambda functions, RDS instance, Cognito, or pipeline services are deployed in this step.
+No API Gateway, Lambda functions, RDS instance, Cognito, or pipeline services are deployed yet.
+
+### Deployment order
+
+`shared-network` and `secrets` are independent — they can be deployed in any order.
+Later stacks (RDS, etc.) will depend on outputs exported from both.
 
 ## Environments
 
-- `dev` stack: `solo-vault-shared-network-dev`
-- `staging` stack: `solo-vault-shared-network-staging`
+- `dev`:
+  - `solo-vault-shared-network-dev`
+  - `solo-vault-secrets-dev`
+- `staging`:
+  - `solo-vault-shared-network-staging`
+  - `solo-vault-secrets-staging`
 - Region: `us-east-1`
 
 Environment config files:
@@ -44,34 +54,88 @@ make install
 
 ## Deploy commands
 
-### npm
+### Make (recommended)
 
 ```bash
-npm run deploy
-npm run deploy:staging
+make deploy STAGE=dev STACK=shared-network
+make deploy STAGE=dev STACK=secrets
+
+make deploy STAGE=staging STACK=shared-network
+make deploy STAGE=staging STACK=secrets
 ```
 
-### Make (explicit stage required)
+`STACK` defaults to `shared-network` if omitted (backwards-compatible with the
+original single-stack workflow).
+
+### npm shortcuts
+
+The named `deploy` scripts are pinned to `shared-network` for backwards compatibility.
+For other stacks, call `iac` directly:
 
 ```bash
-make deploy STAGE=dev
-make deploy STAGE=staging
+# shared-network (dev/staging shortcuts)
+npm run deploy
+npm run deploy:staging
+
+# any stack
+npm run iac -- --env dev     --stack secrets
+npm run iac -- --env staging --stack secrets
 ```
 
 ## Destroy commands (undo)
 
+### Make
+
+```bash
+make destroy STAGE=dev STACK=secrets
+make destroy STAGE=dev STACK=shared-network
+```
+
 ### npm
 
 ```bash
-npm run destroy -- --confirm-destroy solo-vault-shared-network-dev
+# shared-network (dev/staging shortcuts)
+npm run destroy  -- --confirm-destroy solo-vault-shared-network-dev
 npm run destroy:staging -- --confirm-destroy solo-vault-shared-network-staging
-```
 
-### Make (explicit stage required)
-
-```bash
-make destroy STAGE=dev
-make destroy STAGE=staging
+# any stack
+npm run iac -- --action destroy --env dev --stack secrets \
+  --confirm-destroy solo-vault-secrets-dev
 ```
 
 Destroy uses CloudFormation deletion, so resources are removed in dependency-safe order.
+
+## Post-deploy: populating placeholder secrets
+
+The `secrets` stack ships two secrets with `REPLACE_ME` placeholder values
+because CloudFormation can't hold real secret material safely. After the stack
+deploys, populate them with `aws secretsmanager put-secret-value`:
+
+### Embedding API key
+
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id solo-vault/dev/embedding-api-key \
+  --secret-string '{"api_key": "sk-..."}'
+```
+
+### CloudFront signed-URL key pair
+
+Generate a CloudFront key pair in the AWS console (or via the CLI), then:
+
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id solo-vault/dev/cloudfront-key-pair \
+  --secret-string "$(jq -n \
+    --arg kid 'K2EXAMPLE' \
+    --arg pem "$(cat private_key.pem)" \
+    '{key_pair_id: $kid, private_key: $pem}')"
+```
+
+### DB credentials
+
+The `db-credentials` secret is auto-populated at stack-create time with a
+random 32-character password and the configured `DbUsername`. Host, port, and
+dbname fields are left unset — INFRA-5 will attach them via
+`AWS::SecretsManager::SecretTargetAttachment` when the RDS instance is
+provisioned. No manual step needed.

--- a/infra/cloudformation/secrets.yml
+++ b/infra/cloudformation/secrets.yml
@@ -1,0 +1,151 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Solo Vault encryption and secrets baseline (customer-managed KMS keys + Secrets Manager)
+
+Parameters:
+  ProjectPrefix:
+    Type: String
+    AllowedPattern: "^[a-z0-9-]+$"
+  EnvironmentName:
+    Type: String
+    AllowedPattern: "^[a-z0-9-]+$"
+  DbUsername:
+    Type: String
+    Default: solovault
+    AllowedPattern: "^[a-z][a-z0-9_]{2,30}$"
+    Description: Master username seeded into the db-credentials secret. Password is auto-generated.
+
+Resources:
+  S3EncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: !Sub "${ProjectPrefix} ${EnvironmentName} S3 object encryption key"
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: EnableRootAccountPermissions
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+      Tags:
+        - Key: Name
+          Value: !Sub "${ProjectPrefix}-${EnvironmentName}-s3-cmk"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Project
+          Value: !Ref ProjectPrefix
+
+  S3EncryptionKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${ProjectPrefix}-${EnvironmentName}-s3"
+      TargetKeyId: !Ref S3EncryptionKey
+
+  RdsEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: !Sub "${ProjectPrefix} ${EnvironmentName} RDS + Secrets Manager encryption key"
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: EnableRootAccountPermissions
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+      Tags:
+        - Key: Name
+          Value: !Sub "${ProjectPrefix}-${EnvironmentName}-rds-cmk"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Project
+          Value: !Ref ProjectPrefix
+
+  RdsEncryptionKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${ProjectPrefix}-${EnvironmentName}-rds"
+      TargetKeyId: !Ref RdsEncryptionKey
+
+  # Username + password only. INFRA-5 will attach host/port/dbname via
+  # AWS::SecretsManager::SecretTargetAttachment once the RDS instance exists.
+  DbCredentialsSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "${ProjectPrefix}/${EnvironmentName}/db-credentials"
+      Description: RDS master credentials (username + auto-generated password)
+      KmsKeyId: !Ref RdsEncryptionKey
+      GenerateSecretString:
+        SecretStringTemplate: !Sub '{"username": "${DbUsername}"}'
+        GenerateStringKey: password
+        PasswordLength: 32
+        ExcludeCharacters: '"@/\ '
+      Tags:
+        - Key: Name
+          Value: !Sub "${ProjectPrefix}-${EnvironmentName}-db-credentials"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Project
+          Value: !Ref ProjectPrefix
+
+  # Placeholder — populate post-deploy via `aws secretsmanager put-secret-value`.
+  EmbeddingApiKeySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "${ProjectPrefix}/${EnvironmentName}/embedding-api-key"
+      Description: Embedding provider API key (OpenAI or Bedrock). Populated post-deploy.
+      KmsKeyId: !Ref RdsEncryptionKey
+      SecretString: '{"api_key": "REPLACE_ME"}'
+      Tags:
+        - Key: Name
+          Value: !Sub "${ProjectPrefix}-${EnvironmentName}-embedding-api-key"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Project
+          Value: !Ref ProjectPrefix
+
+  # Placeholder — populate post-deploy once the CloudFront distribution + key pair are provisioned.
+  CloudFrontKeyPairSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "${ProjectPrefix}/${EnvironmentName}/cloudfront-key-pair"
+      Description: CloudFront signed-URL key pair (key_pair_id + private_key PEM). Populated post-deploy.
+      KmsKeyId: !Ref RdsEncryptionKey
+      SecretString: '{"key_pair_id": "REPLACE_ME", "private_key": "REPLACE_ME"}'
+      Tags:
+        - Key: Name
+          Value: !Sub "${ProjectPrefix}-${EnvironmentName}-cloudfront-key-pair"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Project
+          Value: !Ref ProjectPrefix
+
+Outputs:
+  S3EncryptionKeyArn:
+    Value: !GetAtt S3EncryptionKey.Arn
+    Export:
+      Name: !Sub "${ProjectPrefix}-${EnvironmentName}-s3-cmk-arn"
+  S3EncryptionKeyAliasName:
+    Value: !Ref S3EncryptionKeyAlias
+  RdsEncryptionKeyArn:
+    Value: !GetAtt RdsEncryptionKey.Arn
+    Export:
+      Name: !Sub "${ProjectPrefix}-${EnvironmentName}-rds-cmk-arn"
+  RdsEncryptionKeyAliasName:
+    Value: !Ref RdsEncryptionKeyAlias
+  DbCredentialsSecretArn:
+    Value: !Ref DbCredentialsSecret
+    Export:
+      Name: !Sub "${ProjectPrefix}-${EnvironmentName}-db-credentials-arn"
+  EmbeddingApiKeySecretArn:
+    Value: !Ref EmbeddingApiKeySecret
+    Export:
+      Name: !Sub "${ProjectPrefix}-${EnvironmentName}-embedding-api-key-arn"
+  CloudFrontKeyPairSecretArn:
+    Value: !Ref CloudFrontKeyPairSecret
+    Export:
+      Name: !Sub "${ProjectPrefix}-${EnvironmentName}-cloudfront-key-pair-arn"

--- a/infra/config/dev.json
+++ b/infra/config/dev.json
@@ -2,13 +2,25 @@
   "project_prefix": "solo-vault",
   "environment": "dev",
   "region": "us-east-1",
-  "stack_name": "solo-vault-shared-network-dev",
-  "vpc_cidr": "10.10.0.0/16",
-  "private_subnet_a_cidr": "10.10.1.0/24",
-  "private_subnet_b_cidr": "10.10.2.0/24",
   "tags": {
     "Project": "solo-vault",
     "Environment": "dev",
     "ManagedBy": "aws-sdk-js-v3"
+  },
+  "stacks": {
+    "shared-network": {
+      "stack_name": "solo-vault-shared-network-dev",
+      "parameters": {
+        "VpcCidr": "10.10.0.0/16",
+        "PrivateSubnetACidr": "10.10.1.0/24",
+        "PrivateSubnetBCidr": "10.10.2.0/24"
+      }
+    },
+    "secrets": {
+      "stack_name": "solo-vault-secrets-dev",
+      "parameters": {
+        "DbUsername": "solovault"
+      }
+    }
   }
 }

--- a/infra/config/staging.json
+++ b/infra/config/staging.json
@@ -2,13 +2,25 @@
   "project_prefix": "solo-vault",
   "environment": "staging",
   "region": "us-east-1",
-  "stack_name": "solo-vault-shared-network-staging",
-  "vpc_cidr": "10.20.0.0/16",
-  "private_subnet_a_cidr": "10.20.1.0/24",
-  "private_subnet_b_cidr": "10.20.2.0/24",
   "tags": {
     "Project": "solo-vault",
     "Environment": "staging",
     "ManagedBy": "aws-sdk-js-v3"
+  },
+  "stacks": {
+    "shared-network": {
+      "stack_name": "solo-vault-shared-network-staging",
+      "parameters": {
+        "VpcCidr": "10.20.0.0/16",
+        "PrivateSubnetACidr": "10.20.1.0/24",
+        "PrivateSubnetBCidr": "10.20.2.0/24"
+      }
+    },
+    "secrets": {
+      "stack_name": "solo-vault-secrets-staging",
+      "parameters": {
+        "DbUsername": "solovault"
+      }
+    }
   }
 }

--- a/infra/scripts/deploy.ts
+++ b/infra/scripts/deploy.ts
@@ -16,15 +16,21 @@ import {
 
 type Environment = "dev" | "staging";
 
+type StackName = "shared-network" | "secrets";
+
+const STACK_NAMES: readonly StackName[] = ["shared-network", "secrets"];
+
+type StackConfig = {
+  stack_name: string;
+  parameters: Record<string, string>;
+};
+
 type DeployConfig = {
   project_prefix: string;
   environment: Environment;
   region: string;
-  stack_name: string;
-  vpc_cidr: string;
-  private_subnet_a_cidr: string;
-  private_subnet_b_cidr: string;
   tags?: Record<string, string>;
+  stacks: Record<StackName, StackConfig>;
 };
 
 type Action = "deploy" | "destroy";
@@ -70,6 +76,22 @@ function parseEnvArg(): Environment {
   return envValue;
 }
 
+function parseStackArg(): StackName {
+  const stackIndex = process.argv.findIndex((arg) => arg === "--stack");
+  if (stackIndex === -1 || stackIndex + 1 >= process.argv.length) {
+    throw new Error(
+      `Missing --stack argument. Allowed: ${STACK_NAMES.join(", ")}.`
+    );
+  }
+  const stackValue = process.argv[stackIndex + 1];
+  if (!STACK_NAMES.includes(stackValue as StackName)) {
+    throw new Error(
+      `Invalid --stack value "${stackValue}". Allowed: ${STACK_NAMES.join(", ")}.`
+    );
+  }
+  return stackValue as StackName;
+}
+
 function loadConfig(env: Environment): DeployConfig {
   const configPath = resolve(process.cwd(), "infra", "config", `${env}.json`);
   const raw = readFileSync(configPath, "utf-8");
@@ -85,14 +107,28 @@ function loadConfig(env: Environment): DeployConfig {
   return config;
 }
 
-function createParameters(config: DeployConfig): Parameter[] {
-  return [
+function resolveStackConfig(config: DeployConfig, stack: StackName): StackConfig {
+  const stackConfig = config.stacks?.[stack];
+  if (!stackConfig) {
+    throw new Error(
+      `Config is missing an entry for stack "${stack}". Add it under the "stacks" key in the env config.`
+    );
+  }
+  return stackConfig;
+}
+
+// Every template takes ProjectPrefix + EnvironmentName; stack-specific parameters
+// are merged in from the env config so this script doesn't need to know which
+// parameters belong to which template.
+function createParameters(config: DeployConfig, stackConfig: StackConfig): Parameter[] {
+  const base: Parameter[] = [
     { ParameterKey: "ProjectPrefix", ParameterValue: config.project_prefix },
-    { ParameterKey: "EnvironmentName", ParameterValue: config.environment },
-    { ParameterKey: "VpcCidr", ParameterValue: config.vpc_cidr },
-    { ParameterKey: "PrivateSubnetACidr", ParameterValue: config.private_subnet_a_cidr },
-    { ParameterKey: "PrivateSubnetBCidr", ParameterValue: config.private_subnet_b_cidr }
+    { ParameterKey: "EnvironmentName", ParameterValue: config.environment }
   ];
+  const custom = Object.entries(stackConfig.parameters ?? {}).map(
+    ([ParameterKey, ParameterValue]): Parameter => ({ ParameterKey, ParameterValue })
+  );
+  return [...base, ...custom];
 }
 
 function createTags(config: DeployConfig): Tag[] {
@@ -141,19 +177,24 @@ async function printOutputs(client: CloudFormationClient, stackName: string): Pr
   }
 }
 
-async function deployStack(client: CloudFormationClient, config: DeployConfig): Promise<void> {
-  const templatePath = resolve(process.cwd(), "infra", "cloudformation", "shared-network.yml");
+async function deployStack(
+  client: CloudFormationClient,
+  config: DeployConfig,
+  stack: StackName,
+  stackConfig: StackConfig
+): Promise<void> {
+  const templatePath = resolve(process.cwd(), "infra", "cloudformation", `${stack}.yml`);
   const templateBody = readFileSync(templatePath, "utf-8");
-  const parameters = createParameters(config);
+  const parameters = createParameters(config, stackConfig);
   const tags = createTags(config);
-  const exists = await stackExists(client, config.stack_name);
+  const exists = await stackExists(client, stackConfig.stack_name);
 
   if (exists) {
     try {
-      console.log(`Updating stack ${config.stack_name} in ${config.region}...`);
+      console.log(`Updating stack ${stackConfig.stack_name} in ${config.region}...`);
       await client.send(
         new UpdateStackCommand({
-          StackName: config.stack_name,
+          StackName: stackConfig.stack_name,
           TemplateBody: templateBody,
           Parameters: parameters,
           Tags: tags
@@ -161,21 +202,21 @@ async function deployStack(client: CloudFormationClient, config: DeployConfig): 
       );
       await waitUntilStackUpdateComplete(
         { client, maxWaitTime: 600 },
-        { StackName: config.stack_name }
+        { StackName: stackConfig.stack_name }
       );
-      console.log(`Stack update complete: ${config.stack_name}`);
+      console.log(`Stack update complete: ${stackConfig.stack_name}`);
     } catch (error) {
       if (isCloudFormationValidationError(error, NO_UPDATES_PATTERN)) {
-        console.log(`No changes detected for stack: ${config.stack_name}`);
+        console.log(`No changes detected for stack: ${stackConfig.stack_name}`);
         return;
       }
       throw error;
     }
   } else {
-    console.log(`Creating stack ${config.stack_name} in ${config.region}...`);
+    console.log(`Creating stack ${stackConfig.stack_name} in ${config.region}...`);
     await client.send(
       new CreateStackCommand({
-        StackName: config.stack_name,
+        StackName: stackConfig.stack_name,
         TemplateBody: templateBody,
         Parameters: parameters,
         Tags: tags
@@ -183,41 +224,47 @@ async function deployStack(client: CloudFormationClient, config: DeployConfig): 
     );
     await waitUntilStackCreateComplete(
       { client, maxWaitTime: 600 },
-      { StackName: config.stack_name }
+      { StackName: stackConfig.stack_name }
     );
-    console.log(`Stack creation complete: ${config.stack_name}`);
+    console.log(`Stack creation complete: ${stackConfig.stack_name}`);
   }
 
-  await printOutputs(client, config.stack_name);
+  await printOutputs(client, stackConfig.stack_name);
 }
 
-async function destroyStack(client: CloudFormationClient, config: DeployConfig): Promise<void> {
-  const exists = await stackExists(client, config.stack_name);
+async function destroyStack(
+  client: CloudFormationClient,
+  stackConfig: StackConfig,
+  region: string
+): Promise<void> {
+  const exists = await stackExists(client, stackConfig.stack_name);
   if (!exists) {
-    console.log(`Stack does not exist, nothing to destroy: ${config.stack_name}`);
+    console.log(`Stack does not exist, nothing to destroy: ${stackConfig.stack_name}`);
     return;
   }
 
-  console.log(`Deleting stack ${config.stack_name} in ${config.region}...`);
-  await client.send(new DeleteStackCommand({ StackName: config.stack_name }));
+  console.log(`Deleting stack ${stackConfig.stack_name} in ${region}...`);
+  await client.send(new DeleteStackCommand({ StackName: stackConfig.stack_name }));
   await waitUntilStackDeleteComplete(
     { client, maxWaitTime: 600 },
-    { StackName: config.stack_name }
+    { StackName: stackConfig.stack_name }
   );
-  console.log(`Stack deletion complete: ${config.stack_name}`);
+  console.log(`Stack deletion complete: ${stackConfig.stack_name}`);
 }
 
 async function run(): Promise<void> {
   const action = parseActionArg();
   const env = parseEnvArg();
+  const stack = parseStackArg();
   const config = loadConfig(env);
+  const stackConfig = resolveStackConfig(config, stack);
   const client = new CloudFormationClient({ region: config.region });
   if (action === "destroy") {
-    parseConfirmDestroyArg(config.stack_name);
-    await destroyStack(client, config);
+    parseConfirmDestroyArg(stackConfig.stack_name);
+    await destroyStack(client, stackConfig, config.region);
     return;
   }
-  await deployStack(client, config);
+  await deployStack(client, config, stack, stackConfig);
 }
 
 run().catch((error) => {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   },
   "scripts": {
     "iac": "node ./node_modules/tsx/dist/cli.mjs infra/scripts/deploy.ts",
-    "deploy": "npm run iac -- --env dev",
-    "deploy:staging": "npm run iac -- --env staging",
-    "destroy": "npm run iac -- --action destroy --env dev",
-    "destroy:staging": "npm run iac -- --action destroy --env staging"
+    "deploy": "npm run iac -- --env dev --stack shared-network",
+    "deploy:staging": "npm run iac -- --env staging --stack shared-network",
+    "destroy": "npm run iac -- --action destroy --env dev --stack shared-network",
+    "destroy:staging": "npm run iac -- --action destroy --env staging --stack shared-network"
   }
 }


### PR DESCRIPTION
Closes #6                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                           
  ## Summary                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                           
  Adds the INFRA-6 encryption and secrets baseline as a new CloudFormation stack                                                                                                                                                                                                           
  (`solo-vault-secrets-{env}`), plus a small refactor of the deploy pipeline so                                                                                                                                                                                                            
  a single script can manage multiple stacks per environment instead of being                                                                                                                                                                                                              
  hardcoded to `shared-network`.                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                           
  Two commits, reviewable independently:                                                                                                                                                                                                                                                   
                                                                  
  - **`42039a3` refactor(infra)** — adds `--stack` flag to `deploy.ts`,                                                                                                                                                                                                                    
    restructures `infra/config/{env}.json` to nest per-stack config under a
    `stacks` key, threads a `STACK` variable through the Makefile (defaulting                                                                                                                                                                                                              
    to `shared-network` for backward compat), updates `deploy.md`.                                                                                                                                                                                                                         
  - **`87dc8c8` feat(infra)** — the actual INFRA-6 template.                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                           
  ## What the new stack creates                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                           
  - **2 customer-managed KMS CMKs** with rotation enabled and aliases:                                                                                                                                                                                                                     
    `alias/solo-vault-{env}-s3` and `alias/solo-vault-{env}-rds`. Default key
    policy grants `kms:*` to the account root so IAM policies on principals                                                                                                                                                                                                                
    can take effect.                                                                                                                                                                                                                                                                       
  - **3 Secrets Manager secrets**, all encrypted with the RDS CMK:                                                                                                                                                                                                                         
    - `solo-vault/{env}/db-credentials` — `GenerateSecretString` seeds the                                                                                                                                                                                                                 
      username (`solovault`, parameterized via `DbUsername`) and a 32-char                                                                                                                                                                                                                 
      auto-generated password at create time.                                                                                                                                                                                                                                              
    - `solo-vault/{env}/embedding-api-key` — placeholder, populate post-deploy                                                                                                                                                                                                             
      via `aws secretsmanager put-secret-value` (documented in `deploy.md`).                                                                                                                                                                                                               
    - `solo-vault/{env}/cloudfront-key-pair` — placeholder, same pattern.                                                                                                                                                                                                                  
  - **7 stack exports** (both CMK ARNs + both aliases + all 3 secret ARNs) so                                                                                                                                                                                                              
    INFRA-4 (S3), INFRA-5 (RDS), and API-3 (files Lambda) can `!ImportValue`                                                                                                                                                                                                               
    them by name.                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                           
  ## Task checklist (from #6)                                                                                                                                                                                                                                                              
                                                                  
  - [x] Create KMS customer-managed key for S3 encryption                                                                                                                                                                                                                                  
  - [x] Create KMS key for RDS encryption
  - [x] Store RDS credentials in Secrets Manager (auto-generated password)                                                                                                                                                                                                                 
  - [x] Store embedding API key in Secrets Manager                
  - [ ] **Deferred**: IAM policies scoping Lambda roles to specific secrets.                                                                                                                                                                                                               
        No Lambda execution roles exist yet — those land with API-1/2/3.                                                                                                                                                                                                                   
        The secret ARNs are exported so policies can reference them when the                                                                                                                                                                                                               
        roles appear. Will be added in those tickets.                                                                                                                                                                                                                                      
  - [ ] **Skipped (optional)**: Automatic rotation for DB credentials. Ticket                                                                                                                                                                                                              
        marks this as optional; can be added as a follow-up before the demo                                                                                                                                                                                                                
        via an AWS-provided rotation Lambda.                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                           
  ## Deviations from the ticket spec                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                           
  1. **Secret names include an `/{env}/` segment** (e.g.                                                                                                                                                                                                                                   
     `solo-vault/dev/db-credentials` vs the ticket's
     `solo-vault/db-credentials`). Necessary so dev and staging secrets can                                                                                                                                                                                                                
     coexist in the same AWS account without colliding. Same reasoning as                                                                                                                                                                                                                  
     the existing `{env}` suffix on stack names and KMS aliases.                                                                                                                                                                                                                           
  2. **`db-credentials` is seeded with `username` + `password` only** —                                                                                                                                                                                                                    
     `host`, `port`, and `dbname` aren't known until RDS exists. INFRA-5 will                                                                                                                                                                                                              
     attach those fields via `AWS::SecretsManager::SecretTargetAttachment`                                                                                                                                                                                                                 
     once the RDS instance is provisioned. Template has a comment explaining                                                                                                                                                                                                               
     this.                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                           
  ## Verification                                                                                                                                                                                                                                                                          
                                                                  
  - `npx tsc --noEmit` clean on the refactored `deploy.ts`.                                                                                                                                                                                                                                
  - `aws cloudformation validate-template` clean on `secrets.yml`.
  - Full deploy → destroy → deploy → destroy cycle against dev:                                                                                                                                                                                                                            
    - `make deploy STAGE=dev STACK=secrets` → `CREATE_COMPLETE`, all 7                                                                                                                                                                                                                     
      outputs populated with real ARNs.                                                                                                                                                                                                                                                    
    - `make destroy STAGE=dev STACK=secrets` → `DELETE_COMPLETE`, stack gone.                                                                                                                                                                                                              
    - Second cycle identical, confirming idempotency.                                                                                                                                                                                                                                      
  - Existing `shared-network` workflow still works (`make deploy STAGE=dev`                                                                                                                                                                                                                
    with no `STACK` argument defaults to `shared-network` via the Makefile).                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                           
  ## Follow-ups (out of scope for this PR)                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                           
  - Lambda IAM policies to read specific secrets (do in API-1/2/3 when                                                                                                                                                                                                                     
    execution roles are created).                                                                                                                                                                                                                                                          
  - Optional: rotation Lambda for `db-credentials` before the demo.                                                                                                                                                                                                                        
  - INFRA-5 will consume this stack's exports and attach host/port/dbname to
    the db-credentials secret.