### PR TITLE
feat(api-2): vault-crud Lambda + VPC stack + APIGW integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 
 # Lambda bundle output (created + cleaned up by infra/scripts/migrate.ts)
 infra/lambda/**/.build/
+.envrc

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ STACK_NAME := solo-vault-$(STACK)-$(STAGE)
 help:
 	@echo "Usage:"
 	@echo "  make install"
-	@echo "  make deploy  STAGE=dev|staging [STACK=shared-network|secrets|rds]"
-	@echo "  make destroy STAGE=dev|staging [STACK=shared-network|secrets|rds]"
+	@echo "  make deploy  STAGE=dev|staging [STACK=shared-network|secrets|rds|network-endpoints|lambda-artifacts]"
+	@echo "  make destroy STAGE=dev|staging [STACK=shared-network|secrets|rds|network-endpoints|lambda-artifacts]"
 	@echo ""
 	@echo "STACK defaults to shared-network."
 
@@ -23,10 +23,10 @@ ensure-args:
 		echo "Error: invalid STAGE '$(STAGE)'. Allowed values: dev, staging."; \
 		exit 1; \
 	fi
-	@if [ "$(STACK)" != "shared-network" ] && [ "$(STACK)" != "secrets" ] && [ "$(STACK)" != "rds" ]; then \
-		echo "Error: invalid STACK '$(STACK)'. Allowed values: shared-network, secrets, rds."; \
-		exit 1; \
-	fi
+	@case "$(STACK)" in \
+		shared-network|secrets|rds|network-endpoints|lambda-artifacts) ;; \
+		*) echo "Error: invalid STACK '$(STACK)'. Allowed: shared-network, secrets, rds, network-endpoints, lambda-artifacts."; exit 1;; \
+	esac
 
 install:
 	npm install

--- a/deploy.md
+++ b/deploy.md
@@ -8,22 +8,31 @@ The deploy script supports multiple CloudFormation stacks via the `--stack` flag
 Each stack has a YAML template under `infra/cloudformation/` and a config entry
 under `stacks.<name>` in `infra/config/{env}.json`.
 
-| Stack            | Template                                      | What it creates                                                                                                  |
-|------------------|-----------------------------------------------|------------------------------------------------------------------------------------------------------------------|
-| `shared-network` | `infra/cloudformation/shared-network.yml`     | 1 VPC, 2 private subnets (AZ-a, AZ-b), Lambda SG, RDS SG (5432 inbound from Lambda SG only)                      |
-| `secrets`        | `infra/cloudformation/secrets.yml`            | 2 customer-managed KMS keys (S3, RDS) + aliases; 3 Secrets Manager secrets (db-credentials, embedding-api-key, cloudfront-key-pair) |
-| `rds`            | `infra/cloudformation/rds.yml`                | Postgres 15 instance (pgvector-capable), DB subnet group, SecretTargetAttachment filling db-credentials with host/port/dbname |
+| Stack                  | Template                                         | What it creates                                                                                                  |
+|------------------------|--------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| `shared-network`       | `infra/cloudformation/shared-network.yml`        | 1 VPC, 2 private subnets (AZ-a, AZ-b), Lambda SG, RDS SG (5432 inbound from Lambda SG only)                      |
+| `secrets`              | `infra/cloudformation/secrets.yml`               | 2 customer-managed KMS keys (S3, RDS) + aliases; 3 Secrets Manager secrets (db-credentials, embedding-api-key, cloudfront-key-pair) |
+| `rds`                  | `infra/cloudformation/rds.yml`                   | Postgres 15 instance (pgvector-capable), DB subnet group, SecretTargetAttachment filling db-credentials with host/port/dbname |
+| `network-endpoints`    | `infra/cloudformation/network-endpoints.yml`     | VPC interface endpoints for Secrets Manager + CloudWatch Logs (single-AZ in private-subnet-a), endpoint SG       |
+| `lambda-artifacts`     | `infra/cloudformation/lambda-artifacts.yml`      | S3 bucket for Lambda zips with 7-day lifecycle expiration                                                        |
+| `vault-crud-lambda`    | `infra/cloudformation/vault-crud-lambda.yml`     | API-2 Lambda + IAM role + API Gateway invoke permission. **Deployed via `npm run deploy:vault-crud` (not via `make deploy`).** |
 
 ### Deployment order
 
-`shared-network` and `secrets` are independent — deploy in any order.
-`rds` depends on exports from both (subnet IDs, RDS SG, RDS KMS key, db-credentials secret), so it must be deployed after both.
-
 ```
 shared-network  ┐
-                ├──►  rds
-secrets         ┘
+                ├──► rds
+secrets         ┤
+                └──► network-endpoints  ──┐
+                                           │
+                     lambda-artifacts  ────┴──► vault-crud-lambda  ──► api-gateway re-deploy
 ```
+
+- `shared-network` and `secrets` are independent.
+- `rds` needs both (subnet IDs, RDS SG, RDS KMS, db-credentials).
+- `network-endpoints` needs `shared-network` (subnet + Lambda SG IDs).
+- `lambda-artifacts` is independent.
+- `vault-crud-lambda` needs `rds` (db-credentials secret), `network-endpoints` (so the Lambda can fetch the secret + ship logs), `lambda-artifacts` (S3 bucket for code), and `api-gateway` (invoke permission scoped to API ID).
 
 ## Environments
 
@@ -65,13 +74,32 @@ make install
 make deploy STAGE=dev STACK=shared-network
 make deploy STAGE=dev STACK=secrets
 make deploy STAGE=dev STACK=rds
+make deploy STAGE=dev STACK=network-endpoints
+make deploy STAGE=dev STACK=lambda-artifacts
 
 make deploy STAGE=staging STACK=shared-network
 make deploy STAGE=staging STACK=secrets
 make deploy STAGE=staging STACK=rds
+make deploy STAGE=staging STACK=network-endpoints
+make deploy STAGE=staging STACK=lambda-artifacts
 ```
 
 Note: `rds` typically takes 10–15 minutes for the initial create.
+
+### Application Lambdas (separate scripts, not via `make deploy`)
+
+Lambdas with bundled dependencies need a build + S3 upload step that
+CloudFormation can't do on its own. Each gets a dedicated script:
+
+```bash
+npm run deploy:vault-crud         # API-2 — vault-crud Lambda + api-gateway re-deploy
+npm run deploy:vault-crud:staging
+```
+
+The script bundles the handler, uploads the zip to the `lambda-artifacts`
+bucket, deploys the `vault-crud-lambda` stack with the new S3 key, then
+patches the `api-gateway` stack to point its 5 `/vault/entries` methods at
+the freshly-deployed Lambda.
 
 `STACK` defaults to `shared-network` if omitted (backwards-compatible with the
 original single-stack workflow).

--- a/infra/cloudformation/api-gateway.yml
+++ b/infra/cloudformation/api-gateway.yml
@@ -20,6 +20,17 @@ Parameters:
     Type: Number
     Default: 100
     Description: Burst capacity for short spikes.
+  VaultCrudLambdaArn:
+    Type: String
+    Default: ""
+    Description: |
+      ARN of the vault-crud Lambda (API-2). When set, the 5 /vault/entries
+      methods become AWS_PROXY integrations to that Lambda. When empty
+      (default), they fall back to the original MOCK 501 behavior so this
+      template is still deployable on its own.
+
+Conditions:
+  VaultCrudWired: !Not [!Equals [!Ref VaultCrudLambdaArn, ""]]
 
 Resources:
   RestApi:
@@ -234,20 +245,26 @@ Resources:
       HttpMethod: GET
       AuthorizationType: COGNITO_USER_POOLS
       AuthorizerId: !Ref CognitoAuthorizer
-      Integration:
-        Type: MOCK
-        RequestTemplates:
-          application/json: '{"statusCode": 501}'
-        IntegrationResponses:
-          - StatusCode: "501"
+      Integration: !If
+        - VaultCrudWired
+        - Type: AWS_PROXY
+          IntegrationHttpMethod: POST
+          Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${VaultCrudLambdaArn}/invocations"
+        - Type: MOCK
+          RequestTemplates:
+            application/json: '{"statusCode": 501}'
+          IntegrationResponses:
+            - StatusCode: "501"
+              ResponseParameters:
+                method.response.header.Access-Control-Allow-Origin: "'*'"
+              ResponseTemplates:
+                application/json: '{"error":{"code":"NOT_IMPLEMENTED","message":"Endpoint not yet implemented (INFRA-3 placeholder)"}}'
+      MethodResponses: !If
+        - VaultCrudWired
+        - - StatusCode: "200"
+        - - StatusCode: "501"
             ResponseParameters:
-              method.response.header.Access-Control-Allow-Origin: "'*'"
-            ResponseTemplates:
-              application/json: '{"error":{"code":"NOT_IMPLEMENTED","message":"Endpoint not yet implemented (INFRA-3 placeholder)"}}'
-      MethodResponses:
-        - StatusCode: "501"
-          ResponseParameters:
-            method.response.header.Access-Control-Allow-Origin: true
+              method.response.header.Access-Control-Allow-Origin: true
 
   VaultEntriesPostMethod:
     Type: AWS::ApiGateway::Method
@@ -257,20 +274,26 @@ Resources:
       HttpMethod: POST
       AuthorizationType: COGNITO_USER_POOLS
       AuthorizerId: !Ref CognitoAuthorizer
-      Integration:
-        Type: MOCK
-        RequestTemplates:
-          application/json: '{"statusCode": 501}'
-        IntegrationResponses:
-          - StatusCode: "501"
+      Integration: !If
+        - VaultCrudWired
+        - Type: AWS_PROXY
+          IntegrationHttpMethod: POST
+          Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${VaultCrudLambdaArn}/invocations"
+        - Type: MOCK
+          RequestTemplates:
+            application/json: '{"statusCode": 501}'
+          IntegrationResponses:
+            - StatusCode: "501"
+              ResponseParameters:
+                method.response.header.Access-Control-Allow-Origin: "'*'"
+              ResponseTemplates:
+                application/json: '{"error":{"code":"NOT_IMPLEMENTED","message":"Endpoint not yet implemented (INFRA-3 placeholder)"}}'
+      MethodResponses: !If
+        - VaultCrudWired
+        - - StatusCode: "201"
+        - - StatusCode: "501"
             ResponseParameters:
-              method.response.header.Access-Control-Allow-Origin: "'*'"
-            ResponseTemplates:
-              application/json: '{"error":{"code":"NOT_IMPLEMENTED","message":"Endpoint not yet implemented (INFRA-3 placeholder)"}}'
-      MethodResponses:
-        - StatusCode: "501"
-          ResponseParameters:
-            method.response.header.Access-Control-Allow-Origin: true
+              method.response.header.Access-Control-Allow-Origin: true
 
   VaultEntriesOptionsMethod:
     Type: AWS::ApiGateway::Method
@@ -306,20 +329,26 @@ Resources:
       AuthorizerId: !Ref CognitoAuthorizer
       RequestParameters:
         method.request.path.id: true
-      Integration:
-        Type: MOCK
-        RequestTemplates:
-          application/json: '{"statusCode": 501}'
-        IntegrationResponses:
-          - StatusCode: "501"
+      Integration: !If
+        - VaultCrudWired
+        - Type: AWS_PROXY
+          IntegrationHttpMethod: POST
+          Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${VaultCrudLambdaArn}/invocations"
+        - Type: MOCK
+          RequestTemplates:
+            application/json: '{"statusCode": 501}'
+          IntegrationResponses:
+            - StatusCode: "501"
+              ResponseParameters:
+                method.response.header.Access-Control-Allow-Origin: "'*'"
+              ResponseTemplates:
+                application/json: '{"error":{"code":"NOT_IMPLEMENTED","message":"Endpoint not yet implemented (INFRA-3 placeholder)"}}'
+      MethodResponses: !If
+        - VaultCrudWired
+        - - StatusCode: "200"
+        - - StatusCode: "501"
             ResponseParameters:
-              method.response.header.Access-Control-Allow-Origin: "'*'"
-            ResponseTemplates:
-              application/json: '{"error":{"code":"NOT_IMPLEMENTED","message":"Endpoint not yet implemented (INFRA-3 placeholder)"}}'
-      MethodResponses:
-        - StatusCode: "501"
-          ResponseParameters:
-            method.response.header.Access-Control-Allow-Origin: true
+              method.response.header.Access-Control-Allow-Origin: true
 
   VaultEntryByIdPutMethod:
     Type: AWS::ApiGateway::Method
@@ -331,20 +360,26 @@ Resources:
       AuthorizerId: !Ref CognitoAuthorizer
       RequestParameters:
         method.request.path.id: true
-      Integration:
-        Type: MOCK
-        RequestTemplates:
-          application/json: '{"statusCode": 501}'
-        IntegrationResponses:
-          - StatusCode: "501"
+      Integration: !If
+        - VaultCrudWired
+        - Type: AWS_PROXY
+          IntegrationHttpMethod: POST
+          Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${VaultCrudLambdaArn}/invocations"
+        - Type: MOCK
+          RequestTemplates:
+            application/json: '{"statusCode": 501}'
+          IntegrationResponses:
+            - StatusCode: "501"
+              ResponseParameters:
+                method.response.header.Access-Control-Allow-Origin: "'*'"
+              ResponseTemplates:
+                application/json: '{"error":{"code":"NOT_IMPLEMENTED","message":"Endpoint not yet implemented (INFRA-3 placeholder)"}}'
+      MethodResponses: !If
+        - VaultCrudWired
+        - - StatusCode: "200"
+        - - StatusCode: "501"
             ResponseParameters:
-              method.response.header.Access-Control-Allow-Origin: "'*'"
-            ResponseTemplates:
-              application/json: '{"error":{"code":"NOT_IMPLEMENTED","message":"Endpoint not yet implemented (INFRA-3 placeholder)"}}'
-      MethodResponses:
-        - StatusCode: "501"
-          ResponseParameters:
-            method.response.header.Access-Control-Allow-Origin: true
+              method.response.header.Access-Control-Allow-Origin: true
 
   VaultEntryByIdDeleteMethod:
     Type: AWS::ApiGateway::Method
@@ -356,20 +391,26 @@ Resources:
       AuthorizerId: !Ref CognitoAuthorizer
       RequestParameters:
         method.request.path.id: true
-      Integration:
-        Type: MOCK
-        RequestTemplates:
-          application/json: '{"statusCode": 501}'
-        IntegrationResponses:
-          - StatusCode: "501"
+      Integration: !If
+        - VaultCrudWired
+        - Type: AWS_PROXY
+          IntegrationHttpMethod: POST
+          Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${VaultCrudLambdaArn}/invocations"
+        - Type: MOCK
+          RequestTemplates:
+            application/json: '{"statusCode": 501}'
+          IntegrationResponses:
+            - StatusCode: "501"
+              ResponseParameters:
+                method.response.header.Access-Control-Allow-Origin: "'*'"
+              ResponseTemplates:
+                application/json: '{"error":{"code":"NOT_IMPLEMENTED","message":"Endpoint not yet implemented (INFRA-3 placeholder)"}}'
+      MethodResponses: !If
+        - VaultCrudWired
+        - - StatusCode: "200"
+        - - StatusCode: "501"
             ResponseParameters:
-              method.response.header.Access-Control-Allow-Origin: "'*'"
-            ResponseTemplates:
-              application/json: '{"error":{"code":"NOT_IMPLEMENTED","message":"Endpoint not yet implemented (INFRA-3 placeholder)"}}'
-      MethodResponses:
-        - StatusCode: "501"
-          ResponseParameters:
-            method.response.header.Access-Control-Allow-Origin: true
+              method.response.header.Access-Control-Allow-Origin: true
 
   VaultEntryByIdOptionsMethod:
     Type: AWS::ApiGateway::Method

--- a/infra/cloudformation/lambda-artifacts.yml
+++ b/infra/cloudformation/lambda-artifacts.yml
@@ -1,0 +1,62 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Solo Vault S3 bucket for Lambda deployment artifacts
+
+# CloudFormation's inline AWS::Lambda::Function Code.ZipFile is capped at 4 KB
+# — fine for trivial inline handlers, useless for anything that bundles
+# dependencies. Application Lambdas (vault-crud, etc.) reference their code
+# from this bucket via Code.S3Bucket + Code.S3Key.
+#
+# The deploy scripts upload zips here and pass S3Key as a stack parameter.
+# Lifecycle rule expires unused zips after 7 days so we don't accumulate
+# stale artifacts; current versions of in-use zips are kept indefinitely
+# because lifecycle expiration only acts on objects, not the latest version
+# referenced by a live Lambda.
+
+Parameters:
+  ProjectPrefix:
+    Type: String
+    AllowedPattern: "^[a-z0-9-]+$"
+  EnvironmentName:
+    Type: String
+    AllowedPattern: "^[a-z0-9-]+$"
+
+Resources:
+  ArtifactsBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      BucketName: !Sub "${ProjectPrefix}-${EnvironmentName}-lambda-artifacts-${AWS::AccountId}"
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Suspended
+      LifecycleConfiguration:
+        Rules:
+          - Id: expire-old-artifacts
+            Status: Enabled
+            ExpirationInDays: 7
+      Tags:
+        - Key: Name
+          Value: !Sub "${ProjectPrefix}-${EnvironmentName}-lambda-artifacts"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Project
+          Value: !Ref ProjectPrefix
+
+Outputs:
+  ArtifactsBucketName:
+    Value: !Ref ArtifactsBucket
+    Export:
+      Name: !Sub "${ProjectPrefix}-${EnvironmentName}-lambda-artifacts-bucket"
+  ArtifactsBucketArn:
+    Value: !GetAtt ArtifactsBucket.Arn
+    Export:
+      Name: !Sub "${ProjectPrefix}-${EnvironmentName}-lambda-artifacts-bucket-arn"

--- a/infra/cloudformation/network-endpoints.yml
+++ b/infra/cloudformation/network-endpoints.yml
@@ -1,0 +1,90 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Solo Vault VPC interface endpoints (Secrets Manager + CloudWatch Logs)
+
+# Why this exists:
+#   The Lambda functions live in private subnets with no NAT gateway. Without
+#   an outbound path they can't reach AWS service APIs over the internet.
+#   Interface endpoints put a private ENI inside our VPC that resolves to the
+#   AWS service over the AWS backbone — no public traffic, no NAT cost.
+#
+# Single-AZ: endpoints live only in private-subnet-a to halve hourly cost
+# (~$0.01/hr per endpoint per AZ). Lambdas using these endpoints must also
+# be deployed only into private-subnet-a — an ENI in subnet-b cannot reach
+# an endpoint that doesn't exist in subnet-b. HA can be added later by
+# putting endpoints in both subnets.
+#
+# Cost: 2 endpoints × 1 AZ × ~$7.20/mo + per-GB data ≈ $14-16/mo.
+
+Parameters:
+  ProjectPrefix:
+    Type: String
+    AllowedPattern: "^[a-z0-9-]+$"
+  EnvironmentName:
+    Type: String
+    AllowedPattern: "^[a-z0-9-]+$"
+
+Resources:
+  # Endpoint ENIs need their own SG. Allow inbound 443 from the Lambda SG so
+  # the SDK calls succeed; nothing else needs in.
+  EndpointSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "VPC interface endpoint access (${EnvironmentName})"
+      VpcId:
+        Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-vpc-id"
+      SecurityGroupIngress:
+        - SourceSecurityGroupId:
+            Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-lambda-sg-id"
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          Description: HTTPS from Lambda SG to AWS service endpoints
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: "-1"
+      Tags:
+        - Key: Name
+          Value: !Sub "${ProjectPrefix}-${EnvironmentName}-vpce-sg"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Project
+          Value: !Ref ProjectPrefix
+
+  SecretsManagerEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcEndpointType: Interface
+      ServiceName: !Sub "com.amazonaws.${AWS::Region}.secretsmanager"
+      VpcId:
+        Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-vpc-id"
+      SubnetIds:
+        - Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-private-subnet-a-id"
+      SecurityGroupIds:
+        - !Ref EndpointSecurityGroup
+      # Required so the standard SDK URL (secretsmanager.us-east-1.amazonaws.com)
+      # resolves to the endpoint ENI instead of the public IP. Without this,
+      # callers would need to pass an --endpoint-url override.
+      PrivateDnsEnabled: true
+
+  CloudWatchLogsEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcEndpointType: Interface
+      ServiceName: !Sub "com.amazonaws.${AWS::Region}.logs"
+      VpcId:
+        Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-vpc-id"
+      SubnetIds:
+        - Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-private-subnet-a-id"
+      SecurityGroupIds:
+        - !Ref EndpointSecurityGroup
+      PrivateDnsEnabled: true
+
+Outputs:
+  EndpointSecurityGroupId:
+    Value: !Ref EndpointSecurityGroup
+    Export:
+      Name: !Sub "${ProjectPrefix}-${EnvironmentName}-vpce-sg-id"
+  SecretsManagerEndpointId:
+    Value: !Ref SecretsManagerEndpoint
+  CloudWatchLogsEndpointId:
+    Value: !Ref CloudWatchLogsEndpoint

--- a/infra/cloudformation/vault-crud-lambda.yml
+++ b/infra/cloudformation/vault-crud-lambda.yml
@@ -1,0 +1,136 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Solo Vault vault-crud Lambda function (API-2)
+
+# Lambda for the 5 /vault/entries CRUD endpoints. Lives in the Lambda SG
+# inside private-subnet-a (single-AZ — same constraint as the VPC interface
+# endpoints in network-endpoints.yml). Reads DB credentials from the
+# db-credentials secret on cold start, caches in module scope, reuses the
+# pg.Pool across warm invocations.
+#
+# Code is uploaded to the artifacts bucket by infra/scripts/deploy-vault-crud.ts;
+# ArtifactsKey is passed in as a parameter so each deploy can point at a
+# fresh zip (object keys are content-hashed by the deploy script).
+
+Parameters:
+  ProjectPrefix:
+    Type: String
+    AllowedPattern: "^[a-z0-9-]+$"
+  EnvironmentName:
+    Type: String
+    AllowedPattern: "^[a-z0-9-]+$"
+  ArtifactsKey:
+    Type: String
+    Description: S3 object key (in the artifacts bucket) of the Lambda zip
+  LambdaMemoryMB:
+    Type: Number
+    Default: 512
+    MinValue: 128
+    MaxValue: 3008
+  LambdaTimeoutSeconds:
+    Type: Number
+    Default: 15
+    MinValue: 3
+    MaxValue: 60
+
+Resources:
+  # Pre-create the log group so we control retention (default is forever) and
+  # so destroying the stack also destroys the logs.
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${ProjectPrefix}-${EnvironmentName}-vault-crud"
+      RetentionInDays: 14
+
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${ProjectPrefix}-${EnvironmentName}-vault-crud-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: { Service: lambda.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        # Includes CloudWatch logs (basic execution) + ENI create/delete (VPC).
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      Policies:
+        - PolicyName: read-db-credentials
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource:
+                  Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-db-credentials-arn"
+              # The db-credentials secret is encrypted with the customer-managed
+              # RdsEncryptionKey, so GetSecretValue also requires kms:Decrypt on
+              # that key (default AWS-managed key wouldn't need this).
+              - Effect: Allow
+                Action: kms:Decrypt
+                Resource:
+                  Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-rds-cmk-arn"
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectPrefix
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  Function:
+    Type: AWS::Lambda::Function
+    DependsOn: LogGroup
+    Properties:
+      FunctionName: !Sub "${ProjectPrefix}-${EnvironmentName}-vault-crud"
+      Runtime: nodejs20.x
+      Handler: index.handler
+      Role: !GetAtt ExecutionRole.Arn
+      Code:
+        S3Bucket:
+          Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-lambda-artifacts-bucket"
+        S3Key: !Ref ArtifactsKey
+      MemorySize: !Ref LambdaMemoryMB
+      Timeout: !Ref LambdaTimeoutSeconds
+      Environment:
+        Variables:
+          DB_SECRET_ID:
+            Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-db-credentials-arn"
+      VpcConfig:
+        # Single subnet — must match the AZ where network-endpoints created
+        # the Secrets Manager + CloudWatch Logs interface endpoints.
+        SubnetIds:
+          - Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-private-subnet-a-id"
+        SecurityGroupIds:
+          - Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-lambda-sg-id"
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectPrefix
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Purpose
+          Value: vault-crud
+
+  # Grant API Gateway permission to invoke the function. Scoped to this API
+  # only via SourceArn; method/path are wildcarded because all 5 routes share
+  # one Lambda.
+  ApiInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt Function.Arn
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub
+        - "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiId}/*/*"
+        - ApiId:
+            Fn::ImportValue: !Sub "${ProjectPrefix}-${EnvironmentName}-api-id"
+
+Outputs:
+  FunctionArn:
+    Value: !GetAtt Function.Arn
+    Export:
+      Name: !Sub "${ProjectPrefix}-${EnvironmentName}-vault-crud-arn"
+  FunctionName:
+    Value: !Ref Function
+    Export:
+      Name: !Sub "${ProjectPrefix}-${EnvironmentName}-vault-crud-name"

--- a/infra/config/dev.json
+++ b/infra/config/dev.json
@@ -33,6 +33,14 @@
         "DbDeletionProtection": "false",
         "DbMultiAz": "false"
       }
+    },
+    "network-endpoints": {
+      "stack_name": "solo-vault-network-endpoints-dev",
+      "parameters": {}
+    },
+    "lambda-artifacts": {
+      "stack_name": "solo-vault-lambda-artifacts-dev",
+      "parameters": {}
     }
   }
 }

--- a/infra/config/staging.json
+++ b/infra/config/staging.json
@@ -33,6 +33,14 @@
         "DbDeletionProtection": "true",
         "DbMultiAz": "false"
       }
+    },
+    "network-endpoints": {
+      "stack_name": "solo-vault-network-endpoints-staging",
+      "parameters": {}
+    },
+    "lambda-artifacts": {
+      "stack_name": "solo-vault-lambda-artifacts-staging",
+      "parameters": {}
     }
   }
 }

--- a/infra/lambda/shared/auth.ts
+++ b/infra/lambda/shared/auth.ts
@@ -1,0 +1,26 @@
+import type { APIGatewayProxyEvent } from "aws-lambda";
+import { ApiError } from "./errors.js";
+
+export interface AuthContext {
+  user_id: string;
+  email?: string;
+}
+
+// API Gateway's Cognito authorizer puts JWT claims under
+// requestContext.authorizer.claims. `sub` is the Cognito user ID and serves
+// as our users.id PK.
+export function requireAuth(event: APIGatewayProxyEvent): AuthContext {
+  const claims = event.requestContext.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  if (!sub) {
+    throw ApiError.unauthorized();
+  }
+
+  return {
+    user_id: sub,
+    email: claims?.email
+  };
+}

--- a/infra/lambda/shared/db.ts
+++ b/infra/lambda/shared/db.ts
@@ -1,0 +1,79 @@
+import { Pool } from "pg";
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand
+} from "@aws-sdk/client-secrets-manager";
+
+interface DbCredentials {
+  host: string;
+  port: number;
+  dbname: string;
+  username: string;
+  password: string;
+}
+
+// Module-level singletons survive across warm Lambda invocations. Cold start
+// pays the secret fetch + pool init; warm invocations reuse both.
+let pool: Pool | undefined;
+const secrets = new SecretsManagerClient({});
+
+async function loadCredentials(): Promise<DbCredentials> {
+  const secretId = process.env.DB_SECRET_ID;
+  if (!secretId) {
+    throw new Error("DB_SECRET_ID environment variable is not set");
+  }
+  const result = await secrets.send(
+    new GetSecretValueCommand({ SecretId: secretId })
+  );
+  if (!result.SecretString) {
+    throw new Error(`Secret ${secretId} has no SecretString`);
+  }
+  return JSON.parse(result.SecretString) as DbCredentials;
+}
+
+export async function getPool(): Promise<Pool> {
+  if (pool) return pool;
+  const creds = await loadCredentials();
+  pool = new Pool({
+    host: creds.host,
+    port: creds.port,
+    database: creds.dbname,
+    user: creds.username,
+    password: creds.password,
+    // Lambda concurrency × max = max DB connections. db.t3.micro caps around
+    // 87 connections; conservative max=3 leaves headroom for pipeline + future
+    // Lambdas. Bump if we ever see "too many connections" in CloudWatch.
+    max: 3,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 5_000,
+    ssl: { rejectUnauthorized: false }
+  });
+  return pool;
+}
+
+export async function query<T>(
+  text: string,
+  params: readonly unknown[] = []
+): Promise<T[]> {
+  const p = await getPool();
+  const result = await p.query(text, params as unknown[]);
+  return result.rows as T[];
+}
+
+// Lazy-create the user row on first request. The auth-handler Lambda (API-1)
+// is supposed to do this on /auth/link, but we can't depend on it being
+// called first — so insert-on-conflict here is cheap and safe.
+export async function ensureUser(
+  userId: string,
+  email: string | undefined
+): Promise<void> {
+  // Cognito always issues an email for our user pool, but be defensive in
+  // case the claim is missing — fall back to a placeholder so the NOT NULL
+  // constraint doesn't trip.
+  const safeEmail = email ?? `${userId}@unknown.local`;
+  await query(
+    `INSERT INTO users (id, email) VALUES ($1, $2)
+       ON CONFLICT (id) DO NOTHING`,
+    [userId, safeEmail]
+  );
+}

--- a/infra/lambda/shared/errors.ts
+++ b/infra/lambda/shared/errors.ts
@@ -1,0 +1,51 @@
+// Error taxonomy mirrored from docs/API.md. Each error has a stable code so
+// clients can branch on it; HTTP status is fixed per error type.
+
+export const ErrorCode = {
+  INVALID_INPUT: "INVALID_INPUT",
+  UNAUTHORIZED: "UNAUTHORIZED",
+  INVALID_TOKEN: "INVALID_TOKEN",
+  FORBIDDEN: "FORBIDDEN",
+  ENTRY_NOT_FOUND: "ENTRY_NOT_FOUND",
+  SESSION_NOT_FOUND: "SESSION_NOT_FOUND",
+  QUOTA_EXCEEDED: "QUOTA_EXCEEDED",
+  COGNITO_ERROR: "COGNITO_ERROR",
+  INTERNAL_ERROR: "INTERNAL_ERROR"
+} as const;
+
+export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: ErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+
+  static invalidInput(message: string) {
+    return new ApiError(400, ErrorCode.INVALID_INPUT, message);
+  }
+
+  static unauthorized(message = "Missing or invalid Cognito JWT") {
+    return new ApiError(401, ErrorCode.UNAUTHORIZED, message);
+  }
+
+  static forbidden(message = "User does not own this resource") {
+    return new ApiError(403, ErrorCode.FORBIDDEN, message);
+  }
+
+  static entryNotFound(id: string) {
+    return new ApiError(
+      404,
+      ErrorCode.ENTRY_NOT_FOUND,
+      `Vault entry with id '${id}' not found`
+    );
+  }
+
+  static internal(message = "Unexpected server error") {
+    return new ApiError(500, ErrorCode.INTERNAL_ERROR, message);
+  }
+}

--- a/infra/lambda/shared/response.ts
+++ b/infra/lambda/shared/response.ts
@@ -1,0 +1,43 @@
+import type { APIGatewayProxyResult } from "aws-lambda";
+import { ApiError, ErrorCode } from "./errors.js";
+
+// CORS open in dev. Tighten to Tauri origins before staging:
+//   tauri://localhost, https://tauri.localhost, http://localhost:*
+const JSON_HEADERS = {
+  "Content-Type": "application/json",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Authorization,Content-Type",
+  "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS"
+};
+
+export function ok<T>(body: T, status = 200): APIGatewayProxyResult {
+  return {
+    statusCode: status,
+    headers: JSON_HEADERS,
+    body: JSON.stringify(body)
+  };
+}
+
+export function created<T>(body: T): APIGatewayProxyResult {
+  return ok(body, 201);
+}
+
+export function error(
+  status: number,
+  code: ErrorCode,
+  message: string
+): APIGatewayProxyResult {
+  return {
+    statusCode: status,
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ error: { code, message } })
+  };
+}
+
+export function handleError(err: unknown): APIGatewayProxyResult {
+  if (err instanceof ApiError) {
+    return error(err.status, err.code, err.message);
+  }
+  console.error("Unhandled error:", err);
+  return error(500, ErrorCode.INTERNAL_ERROR, "Unexpected server error");
+}

--- a/infra/lambda/shared/types.ts
+++ b/infra/lambda/shared/types.ts
@@ -1,0 +1,21 @@
+export type EntryType = "note" | "file" | "snippet" | "config" | "keyvalue";
+
+export type IndexStatus = "pending" | "indexing" | "indexed" | "failed";
+
+export interface VaultEntry {
+  id: string;
+  user_id: string;
+  project_id: string | null;
+  title: string;
+  content: string | null;
+  entry_type: EntryType;
+  tags: string[];
+  metadata: Record<string, unknown>;
+  s3_key: string | null;
+  file_name: string | null;
+  file_size: number | null;
+  mime_type: string | null;
+  index_status: IndexStatus;
+  created_at: string;
+  updated_at: string;
+}

--- a/infra/lambda/vault-crud/create.ts
+++ b/infra/lambda/vault-crud/create.ts
@@ -1,0 +1,55 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { z } from "zod";
+import { created } from "../shared/response.js";
+import { ApiError } from "../shared/errors.js";
+import { query } from "../shared/db.js";
+import type { AuthContext } from "../shared/auth.js";
+import type { VaultEntry } from "../shared/types.js";
+
+const CreateRequest = z.object({
+  title: z.string().min(1).max(500),
+  content: z.string().optional(),
+  entry_type: z.enum(["note", "file", "snippet", "config", "keyvalue"]),
+  tags: z.array(z.string()).default([]),
+  metadata: z.record(z.unknown()).default({}),
+  project_id: z.string().uuid().nullable().optional()
+});
+
+export async function createEntry(
+  event: APIGatewayProxyEvent,
+  auth: AuthContext
+): Promise<APIGatewayProxyResult> {
+  let body: unknown;
+  try {
+    body = event.body ? JSON.parse(event.body) : {};
+  } catch {
+    throw ApiError.invalidInput("Request body is not valid JSON");
+  }
+  const parsed = CreateRequest.safeParse(body);
+  if (!parsed.success) {
+    throw ApiError.invalidInput(
+      parsed.error.issues[0]?.message ?? "Invalid body"
+    );
+  }
+  const input = parsed.data;
+
+  // index_status defaults to 'pending' per schema. File entries leave
+  // s3_key null until vault-files (API-3) issues an upload URL.
+  const rows = await query<VaultEntry>(
+    `INSERT INTO vault_entries
+       (user_id, project_id, title, content, entry_type, tags, metadata)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING *`,
+    [
+      auth.user_id,
+      input.project_id ?? null,
+      input.title,
+      input.content ?? null,
+      input.entry_type,
+      input.tags,
+      input.metadata
+    ]
+  );
+
+  return created(rows[0]);
+}

--- a/infra/lambda/vault-crud/delete.ts
+++ b/infra/lambda/vault-crud/delete.ts
@@ -1,0 +1,42 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { z } from "zod";
+import { ok } from "../shared/response.js";
+import { ApiError } from "../shared/errors.js";
+import { query } from "../shared/db.js";
+import type { AuthContext } from "../shared/auth.js";
+import type { VaultEntry } from "../shared/types.js";
+
+const PathSchema = z.object({ id: z.string().uuid() });
+
+export async function deleteEntry(
+  event: APIGatewayProxyEvent,
+  auth: AuthContext
+): Promise<APIGatewayProxyResult> {
+  const parsed = PathSchema.safeParse(event.pathParameters ?? {});
+  if (!parsed.success) {
+    throw ApiError.invalidInput("Path parameter 'id' must be a UUID");
+  }
+  const { id } = parsed.data;
+
+  // Single statement does ownership check + delete + returns the deleted
+  // row's s3_key (for the future S3 cleanup step). vault_chunks /
+  // vault_chunk_parents cascade automatically via ON DELETE CASCADE in the
+  // schema.
+  const rows = await query<Pick<VaultEntry, "id" | "s3_key">>(
+    `DELETE FROM vault_entries
+      WHERE id = $1 AND user_id = $2
+     RETURNING id, s3_key`,
+    [id, auth.user_id]
+  );
+  if (rows.length === 0) {
+    throw ApiError.entryNotFound(id);
+  }
+
+  // TODO(API-3 / INFRA-4): if rows[0].s3_key is set, also delete the S3
+  // object. Skipped here because the S3 bucket isn't provisioned yet
+  // (INFRA-4 not done) and uploads aren't wired (API-3 not done).
+  // Leaving an orphaned S3 object on entry delete is harmless until the
+  // bucket exists; it'll just need a one-shot cleanup before demo.
+
+  return ok({ deleted: true, id: rows[0].id });
+}

--- a/infra/lambda/vault-crud/get.ts
+++ b/infra/lambda/vault-crud/get.ts
@@ -1,0 +1,32 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { z } from "zod";
+import { ok } from "../shared/response.js";
+import { ApiError } from "../shared/errors.js";
+import { query } from "../shared/db.js";
+import type { AuthContext } from "../shared/auth.js";
+import type { VaultEntry } from "../shared/types.js";
+
+const PathSchema = z.object({ id: z.string().uuid() });
+
+export async function getEntry(
+  event: APIGatewayProxyEvent,
+  auth: AuthContext
+): Promise<APIGatewayProxyResult> {
+  const parsed = PathSchema.safeParse(event.pathParameters ?? {});
+  if (!parsed.success) {
+    throw ApiError.invalidInput("Path parameter 'id' must be a UUID");
+  }
+  const { id } = parsed.data;
+
+  // user_id is in the WHERE clause to prevent IDOR — even if a user guesses
+  // another user's UUID, they get 404 not 403. Either response leaks
+  // existence; 404 leaks less.
+  const rows = await query<VaultEntry>(
+    `SELECT * FROM vault_entries WHERE id = $1 AND user_id = $2`,
+    [id, auth.user_id]
+  );
+  if (rows.length === 0) {
+    throw ApiError.entryNotFound(id);
+  }
+  return ok(rows[0]);
+}

--- a/infra/lambda/vault-crud/index.ts
+++ b/infra/lambda/vault-crud/index.ts
@@ -1,0 +1,36 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { handleError } from "../shared/response.js";
+import { requireAuth } from "../shared/auth.js";
+import { ensureUser } from "../shared/db.js";
+import { listEntries } from "./list.js";
+import { createEntry } from "./create.js";
+import { getEntry } from "./get.js";
+import { updateEntry } from "./update.js";
+import { deleteEntry } from "./delete.js";
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const auth = requireAuth(event);
+    await ensureUser(auth.user_id, auth.email);
+
+    const route = `${event.httpMethod} ${event.resource}`;
+    switch (route) {
+      case "GET /vault/entries":
+        return await listEntries(event, auth);
+      case "POST /vault/entries":
+        return await createEntry(event, auth);
+      case "GET /vault/entries/{id}":
+        return await getEntry(event, auth);
+      case "PUT /vault/entries/{id}":
+        return await updateEntry(event, auth);
+      case "DELETE /vault/entries/{id}":
+        return await deleteEntry(event, auth);
+      default:
+        return handleError(new Error(`Unsupported route: ${route}`));
+    }
+  } catch (err) {
+    return handleError(err);
+  }
+};

--- a/infra/lambda/vault-crud/list.ts
+++ b/infra/lambda/vault-crud/list.ts
@@ -1,0 +1,80 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { z } from "zod";
+import { ok } from "../shared/response.js";
+import { ApiError } from "../shared/errors.js";
+import { query } from "../shared/db.js";
+import type { AuthContext } from "../shared/auth.js";
+import type { VaultEntry } from "../shared/types.js";
+
+const ListQuery = z.object({
+  project_id: z.string().uuid().optional(),
+  scope: z.enum(["project", "global", "all"]).default("all"),
+  tags: z.string().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20)
+});
+
+interface Row extends VaultEntry {
+  total: string; // COUNT(*) OVER () comes back as a numeric string
+}
+
+export async function listEntries(
+  event: APIGatewayProxyEvent,
+  auth: AuthContext
+): Promise<APIGatewayProxyResult> {
+  const parsed = ListQuery.safeParse(event.queryStringParameters ?? {});
+  if (!parsed.success) {
+    throw ApiError.invalidInput(
+      parsed.error.issues[0]?.message ?? "Invalid query"
+    );
+  }
+  const { project_id, scope, tags, page, limit } = parsed.data;
+
+  if (scope === "project" && !project_id) {
+    throw ApiError.invalidInput(
+      "scope=project requires a project_id query parameter"
+    );
+  }
+
+  const tagList = tags
+    ? tags.split(",").map((t) => t.trim()).filter(Boolean)
+    : [];
+
+  // Build the WHERE clause incrementally so each branch contributes its own
+  // parameters and we never interpolate user input into the SQL string.
+  const conditions: string[] = ["user_id = $1"];
+  const params: unknown[] = [auth.user_id];
+
+  if (scope === "project") {
+    params.push(project_id);
+    conditions.push(`project_id = $${params.length}`);
+  } else if (scope === "global") {
+    conditions.push("project_id IS NULL");
+  }
+  // scope === "all" → no additional condition
+
+  if (tagList.length > 0) {
+    params.push(tagList);
+    // tags @> $N → "row.tags contains all of $N" (AND semantics per issue spec)
+    conditions.push(`tags @> $${params.length}`);
+  }
+
+  params.push(limit);
+  const limitParam = `$${params.length}`;
+  params.push((page - 1) * limit);
+  const offsetParam = `$${params.length}`;
+
+  const sql = `
+    SELECT *, COUNT(*) OVER () AS total
+    FROM vault_entries
+    WHERE ${conditions.join(" AND ")}
+    ORDER BY updated_at DESC
+    LIMIT ${limitParam} OFFSET ${offsetParam}
+  `;
+  const rows = await query<Row>(sql, params);
+
+  const total = rows.length > 0 ? Number(rows[0].total) : 0;
+  const entries: VaultEntry[] = rows.map(({ total: _t, ...entry }) => entry);
+
+  return ok({ entries, total, page });
+}

--- a/infra/lambda/vault-crud/update.ts
+++ b/infra/lambda/vault-crud/update.ts
@@ -1,0 +1,87 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { z } from "zod";
+import { ok } from "../shared/response.js";
+import { ApiError } from "../shared/errors.js";
+import { query } from "../shared/db.js";
+import type { AuthContext } from "../shared/auth.js";
+import type { VaultEntry } from "../shared/types.js";
+
+const PathSchema = z.object({ id: z.string().uuid() });
+
+const UpdateRequest = z
+  .object({
+    title: z.string().min(1).max(500).optional(),
+    content: z.string().nullable().optional(),
+    tags: z.array(z.string()).optional(),
+    metadata: z.record(z.unknown()).optional()
+  })
+  .refine(
+    (data) => Object.keys(data).length > 0,
+    { message: "At least one field must be provided" }
+  );
+
+export async function updateEntry(
+  event: APIGatewayProxyEvent,
+  auth: AuthContext
+): Promise<APIGatewayProxyResult> {
+  const path = PathSchema.safeParse(event.pathParameters ?? {});
+  if (!path.success) {
+    throw ApiError.invalidInput("Path parameter 'id' must be a UUID");
+  }
+  const { id } = path.data;
+
+  let body: unknown;
+  try {
+    body = event.body ? JSON.parse(event.body) : {};
+  } catch {
+    throw ApiError.invalidInput("Request body is not valid JSON");
+  }
+  const parsed = UpdateRequest.safeParse(body);
+  if (!parsed.success) {
+    throw ApiError.invalidInput(
+      parsed.error.issues[0]?.message ?? "Invalid body"
+    );
+  }
+  const input = parsed.data;
+
+  // Build dynamic SET — only update fields the caller sent. updated_at is
+  // bumped unconditionally. If content is being changed, reset the index
+  // pipeline so chunks/embeddings get rebuilt.
+  const sets: string[] = ["updated_at = now()"];
+  const params: unknown[] = [];
+
+  if (input.title !== undefined) {
+    params.push(input.title);
+    sets.push(`title = $${params.length}`);
+  }
+  if (input.content !== undefined) {
+    params.push(input.content);
+    sets.push(`content = $${params.length}`);
+    sets.push(`index_status = 'pending'`);
+  }
+  if (input.tags !== undefined) {
+    params.push(input.tags);
+    sets.push(`tags = $${params.length}`);
+  }
+  if (input.metadata !== undefined) {
+    params.push(input.metadata);
+    sets.push(`metadata = $${params.length}`);
+  }
+
+  params.push(id);
+  const idParam = `$${params.length}`;
+  params.push(auth.user_id);
+  const userParam = `$${params.length}`;
+
+  const rows = await query<VaultEntry>(
+    `UPDATE vault_entries
+        SET ${sets.join(", ")}
+      WHERE id = ${idParam} AND user_id = ${userParam}
+     RETURNING *`,
+    params
+  );
+  if (rows.length === 0) {
+    throw ApiError.entryNotFound(id);
+  }
+  return ok(rows[0]);
+}

--- a/infra/scripts/deploy-api-gateway.ts
+++ b/infra/scripts/deploy-api-gateway.ts
@@ -117,6 +117,21 @@ async function deployStack(client: CloudFormationClient, config: BaseConfig): Pr
   const tags = createTags(config);
   const exists = await stackExists(client, name);
 
+  // VaultCrudLambdaArn is set by infra/scripts/deploy-vault-crud.ts (API-2).
+  // If the stack already has it set to a real ARN, we don't want a plain
+  // `deploy:apigw` to reset it back to "" and break the integration. So on
+  // update, look up the existing value and reuse it via UsePreviousValue.
+  if (exists) {
+    const result = await client.send(new DescribeStacksCommand({ StackName: name }));
+    const existingParams = result.Stacks?.[0]?.Parameters ?? [];
+    const hasVaultCrudArn = existingParams.some(
+      (p) => p.ParameterKey === "VaultCrudLambdaArn"
+    );
+    if (hasVaultCrudArn) {
+      parameters.push({ ParameterKey: "VaultCrudLambdaArn", UsePreviousValue: true });
+    }
+  }
+
   if (exists) {
     try {
       console.log(`Updating stack ${name} in ${config.region}...`);

--- a/infra/scripts/deploy-vault-crud.ts
+++ b/infra/scripts/deploy-vault-crud.ts
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+// Deploys the vault-crud Lambda (API-2):
+//   1. Bundles infra/lambda/vault-crud + shared utilities into one zip
+//   2. Uploads to the lambda-artifacts S3 bucket under a content-hashed key
+//   3. Creates or updates the vault-crud-lambda CloudFormation stack with
+//      that S3 key as ArtifactsKey
+//   4. Patches the api-gateway stack: passes the new Lambda ARN so the
+//      5 /vault/entries methods switch from MOCK to AWS_PROXY
+//
+// Step 4 only updates the VaultCrudLambdaArn parameter; everything else on
+// the api-gateway stack uses UsePreviousValue, so this won't reset other
+// params (StageName, throttle limits) to defaults.
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { build as esbuild } from "esbuild";
+import AdmZip from "adm-zip";
+import {
+  CloudFormationClient,
+  CreateStackCommand,
+  DescribeStacksCommand,
+  ListExportsCommand,
+  UpdateStackCommand,
+  waitUntilStackCreateComplete,
+  waitUntilStackUpdateComplete
+} from "@aws-sdk/client-cloudformation";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  APIGatewayClient,
+  CreateDeploymentCommand
+} from "@aws-sdk/client-api-gateway";
+
+type Environment = "dev" | "staging";
+type BaseConfig = {
+  project_prefix: string;
+  environment: Environment;
+  region: string;
+  tags?: Record<string, string>;
+};
+
+function parseEnvArg(): Environment {
+  const i = process.argv.findIndex((a) => a === "--env");
+  if (i === -1 || i + 1 >= process.argv.length) {
+    throw new Error("Missing --env argument. Use --env dev or --env staging.");
+  }
+  const v = process.argv[i + 1];
+  if (v !== "dev" && v !== "staging") {
+    throw new Error("Invalid --env value. Allowed: dev, staging.");
+  }
+  return v;
+}
+
+function loadConfig(env: Environment): BaseConfig {
+  const path = resolve(process.cwd(), "infra", "config", `${env}.json`);
+  return JSON.parse(readFileSync(path, "utf-8")) as BaseConfig;
+}
+
+async function resolveExport(
+  cfn: CloudFormationClient,
+  name: string
+): Promise<string> {
+  let next: string | undefined;
+  do {
+    const response = await cfn.send(new ListExportsCommand({ NextToken: next }));
+    const match = response.Exports?.find((e) => e.Name === name);
+    if (match?.Value) return match.Value;
+    next = response.NextToken;
+  } while (next);
+  throw new Error(`CloudFormation export "${name}" not found`);
+}
+
+async function bundleLambda(): Promise<{ zipPath: string; hash: string; cleanup: () => void }> {
+  const srcEntry = resolve(
+    process.cwd(),
+    "infra",
+    "lambda",
+    "vault-crud",
+    "index.ts"
+  );
+  const buildDir = resolve(
+    process.cwd(),
+    "infra",
+    "lambda",
+    "vault-crud",
+    ".build"
+  );
+  mkdirSync(buildDir, { recursive: true });
+  const outFile = resolve(buildDir, "index.js");
+
+  await esbuild({
+    entryPoints: [srcEntry],
+    bundle: true,
+    platform: "node",
+    target: "node20",
+    format: "cjs",
+    outfile: outFile,
+    external: ["@aws-sdk/*", "pg-native"]
+  });
+
+  const zip = new AdmZip();
+  zip.addLocalFile(outFile);
+  const zipPath = resolve(buildDir, "function.zip");
+  zip.writeZip(zipPath);
+
+  // Hash the zip bytes so each unique build gets a unique S3 key. CFN sees
+  // a real change in ArtifactsKey and updates the Lambda code.
+  const bytes = readFileSync(zipPath);
+  const hash = createHash("sha256").update(bytes).digest("hex").slice(0, 16);
+
+  return {
+    zipPath,
+    hash,
+    cleanup: () => rmSync(buildDir, { recursive: true, force: true })
+  };
+}
+
+async function stackExists(
+  cfn: CloudFormationClient,
+  stackName: string
+): Promise<boolean> {
+  try {
+    await cfn.send(new DescribeStacksCommand({ StackName: stackName }));
+    return true;
+  } catch (err) {
+    if (err instanceof Error && /does not exist/i.test(err.message)) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+async function getStackOutput(
+  cfn: CloudFormationClient,
+  stackName: string,
+  outputKey: string
+): Promise<string> {
+  const response = await cfn.send(
+    new DescribeStacksCommand({ StackName: stackName })
+  );
+  const output = response.Stacks?.[0]?.Outputs?.find(
+    (o) => o.OutputKey === outputKey
+  );
+  if (!output?.OutputValue) {
+    throw new Error(
+      `Stack ${stackName} has no output named ${outputKey}`
+    );
+  }
+  return output.OutputValue;
+}
+
+async function deployLambdaStack(
+  cfn: CloudFormationClient,
+  config: BaseConfig,
+  artifactsKey: string
+): Promise<string> {
+  const stackName = `${config.project_prefix}-vault-crud-lambda-${config.environment}`;
+  const templateBody = readFileSync(
+    resolve(process.cwd(), "infra", "cloudformation", "vault-crud-lambda.yml"),
+    "utf-8"
+  );
+  const parameters = [
+    { ParameterKey: "ProjectPrefix", ParameterValue: config.project_prefix },
+    { ParameterKey: "EnvironmentName", ParameterValue: config.environment },
+    { ParameterKey: "ArtifactsKey", ParameterValue: artifactsKey }
+  ];
+  const tags = Object.entries(config.tags ?? {}).map(([Key, Value]) => ({
+    Key,
+    Value
+  }));
+  const exists = await stackExists(cfn, stackName);
+
+  if (exists) {
+    try {
+      console.log(`Updating ${stackName}...`);
+      await cfn.send(
+        new UpdateStackCommand({
+          StackName: stackName,
+          TemplateBody: templateBody,
+          Parameters: parameters,
+          Capabilities: ["CAPABILITY_NAMED_IAM"],
+          Tags: tags
+        })
+      );
+      await waitUntilStackUpdateComplete(
+        { client: cfn, maxWaitTime: 600 },
+        { StackName: stackName }
+      );
+    } catch (err) {
+      if (err instanceof Error && /No updates are to be performed/i.test(err.message)) {
+        console.log(`No changes for ${stackName}.`);
+      } else {
+        throw err;
+      }
+    }
+  } else {
+    console.log(`Creating ${stackName}...`);
+    await cfn.send(
+      new CreateStackCommand({
+        StackName: stackName,
+        TemplateBody: templateBody,
+        Parameters: parameters,
+        Capabilities: ["CAPABILITY_NAMED_IAM"],
+        Tags: tags
+      })
+    );
+    await waitUntilStackCreateComplete(
+      { client: cfn, maxWaitTime: 600 },
+      { StackName: stackName }
+    );
+  }
+
+  return getStackOutput(cfn, stackName, "FunctionArn");
+}
+
+async function patchApiGateway(
+  cfn: CloudFormationClient,
+  apigw: APIGatewayClient,
+  config: BaseConfig,
+  lambdaArn: string
+): Promise<void> {
+  const stackName = `${config.project_prefix}-api-gateway-${config.environment}`;
+  const templateBody = readFileSync(
+    resolve(process.cwd(), "infra", "cloudformation", "api-gateway.yml"),
+    "utf-8"
+  );
+
+  // Pull the existing parameter list and reuse all values except
+  // VaultCrudLambdaArn — which we set to the new ARN.
+  const existing = await cfn.send(
+    new DescribeStacksCommand({ StackName: stackName })
+  );
+  const existingParams = existing.Stacks?.[0]?.Parameters ?? [];
+  const parameters = existingParams.map((p) => {
+    if (p.ParameterKey === "VaultCrudLambdaArn") {
+      return { ParameterKey: "VaultCrudLambdaArn", ParameterValue: lambdaArn };
+    }
+    return { ParameterKey: p.ParameterKey, UsePreviousValue: true };
+  });
+  // If the existing stack predates our parameter (deployed before this PR),
+  // there's no entry for VaultCrudLambdaArn in existingParams — append it.
+  if (!existingParams.some((p) => p.ParameterKey === "VaultCrudLambdaArn")) {
+    parameters.push({
+      ParameterKey: "VaultCrudLambdaArn",
+      ParameterValue: lambdaArn
+    });
+  }
+
+  try {
+    console.log(`Patching ${stackName} with vault-crud Lambda ARN...`);
+    await cfn.send(
+      new UpdateStackCommand({
+        StackName: stackName,
+        TemplateBody: templateBody,
+        Parameters: parameters
+      })
+    );
+    await waitUntilStackUpdateComplete(
+      { client: cfn, maxWaitTime: 600 },
+      { StackName: stackName }
+    );
+    console.log(`api-gateway updated.`);
+  } catch (err) {
+    if (err instanceof Error && /No updates are to be performed/i.test(err.message)) {
+      console.log(`No changes for ${stackName}.`);
+    } else {
+      throw err;
+    }
+  }
+
+  // CFN updates the Method/Integration resources, but the live stage keeps
+  // serving the previous Deployment snapshot until something explicitly
+  // creates a new one. Force it here so the new AWS_PROXY routes go live.
+  const apiId = existing.Stacks?.[0]?.Outputs?.find(
+    (o) => o.OutputKey === "ApiId"
+  )?.OutputValue;
+  const stageName = existingParams.find(
+    (p) => p.ParameterKey === "StageName"
+  )?.ParameterValue;
+  if (!apiId || !stageName) {
+    throw new Error(
+      `Could not resolve ApiId/StageName from ${stackName} for redeploy`
+    );
+  }
+  console.log(`Forcing new APIGW deployment on ${apiId}:${stageName}...`);
+  await apigw.send(
+    new CreateDeploymentCommand({
+      restApiId: apiId,
+      stageName,
+      description: `vault-crud deploy: pick up new method integrations`
+    })
+  );
+}
+
+async function run(): Promise<void> {
+  const env = parseEnvArg();
+  const config = loadConfig(env);
+  const cfn = new CloudFormationClient({ region: config.region });
+  const s3 = new S3Client({ region: config.region });
+  const apigw = new APIGatewayClient({ region: config.region });
+
+  const prefix = `${config.project_prefix}-${config.environment}`;
+  const bucketName = await resolveExport(
+    cfn,
+    `${prefix}-lambda-artifacts-bucket`
+  );
+  console.log(`Artifacts bucket: ${bucketName}`);
+
+  const bundle = await bundleLambda();
+  try {
+    const s3Key = `vault-crud/${bundle.hash}.zip`;
+    console.log(`Uploading zip → s3://${bucketName}/${s3Key}`);
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: s3Key,
+        Body: readFileSync(bundle.zipPath),
+        ContentType: "application/zip"
+      })
+    );
+
+    const lambdaArn = await deployLambdaStack(cfn, config, s3Key);
+    console.log(`vault-crud Lambda ARN: ${lambdaArn}`);
+
+    await patchApiGateway(cfn, apigw, config, lambdaArn);
+
+    console.log("\nDone. /vault/entries methods are now wired to the Lambda.");
+  } finally {
+    bundle.cleanup();
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/infra/scripts/deploy.ts
+++ b/infra/scripts/deploy.ts
@@ -16,9 +16,20 @@ import {
 
 type Environment = "dev" | "staging";
 
-type StackName = "shared-network" | "secrets" | "rds";
+type StackName =
+  | "shared-network"
+  | "secrets"
+  | "rds"
+  | "network-endpoints"
+  | "lambda-artifacts";
 
-const STACK_NAMES: readonly StackName[] = ["shared-network", "secrets", "rds"];
+const STACK_NAMES: readonly StackName[] = [
+  "shared-network",
+  "secrets",
+  "rds",
+  "network-endpoints",
+  "lambda-artifacts"
+];
 
 type StackConfig = {
   stack_name: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,19 @@
       "name": "solo-vault-backend",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-api-gateway": "^3.1041.0",
         "@aws-sdk/client-cloudformation": "^3.908.0",
         "@aws-sdk/client-iam": "^3.908.0",
         "@aws-sdk/client-lambda": "^3.908.0",
+        "@aws-sdk/client-s3": "^3.908.0",
         "@aws-sdk/client-secrets-manager": "^3.908.0",
         "adm-zip": "^0.5.16",
-        "pg": "^8.13.0"
+        "pg": "^8.13.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/adm-zip": "^0.5.7",
+        "@types/aws-lambda": "^8.10.145",
         "@types/node": "^22.15.3",
         "@types/pg": "^8.11.0",
         "esbuild": "^0.24.0",
@@ -39,6 +43,69 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -154,6 +221,58 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-api-gateway": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-api-gateway/-/client-api-gateway-3.1041.0.tgz",
+      "integrity": "sha512-eJ/GjLeJgXGWqF4f3s8JQ7OhJjxsyFwweGlHXU/QNteSH7J3DxEBgptYFXs5rG+2/b6YK9o0K8hLfMQMj2QWwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-api-gateway": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cloudformation": {
@@ -312,6 +431,72 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1038.0.tgz",
+      "integrity": "sha512-k60qm50bWkaqNfCJe1z28WaqgpztE0wbWVMZw6ZJcTOGfrWFhsJeLCEqtkH8w00iEozKx9GQwdQXz4G0sMGdKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
+        "@aws-sdk/middleware-expect-continue": "^3.972.10",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.14",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-blob-browser": "^4.2.15",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/hash-stream-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/md5-js": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-secrets-manager": {
       "version": "3.1033.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1033.0.tgz",
@@ -363,22 +548,23 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.2.tgz",
-      "integrity": "sha512-oav5AOAz+1XkwUfp6SrEm42UPDpUP5D4jNYXkDwFR1VfWqYX62+jpytdfzURmJ9McSoJIQwi0OJlC4oCi6t0VQ==",
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.18",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/xml-builder": "^3.972.22",
+        "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -386,13 +572,26 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.28.tgz",
-      "integrity": "sha512-87GdRJ2OR0qR4VkMjXN/SZi66DZsunW2qQCbtw9rKw3Y7JurFi6tQWYKOSLY/gOADrU6OxGqFmdw3hKzZqDZOQ==",
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
+      "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/types": "^4.14.1",
@@ -403,20 +602,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.30.tgz",
-      "integrity": "sha512-6quozmW2PKwBJTUQLb+lk1q8w5Pm45qaqhx4Tld9EIqYYQOVGj+MT0a8NRVS7QgWJj7rzGlB7rQu3KYBFHemJw==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -424,19 +623,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.32.tgz",
-      "integrity": "sha512-Nkr+UKtczZlocUjc6g96WzQadZSIZO/HVXPki4qbfaVOZYSbfLQKWKfADtJ0kGYsCvSYOZrO66tSc9dkboUt/w==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/credential-provider-env": "^3.972.28",
-        "@aws-sdk/credential-provider-http": "^3.972.30",
-        "@aws-sdk/credential-provider-login": "^3.972.32",
-        "@aws-sdk/credential-provider-process": "^3.972.28",
-        "@aws-sdk/credential-provider-sso": "^3.972.32",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.32",
-        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -449,13 +648,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.32.tgz",
-      "integrity": "sha512-UxgwT1HmZz1QPXuBy5ZUPJNFXOSlhwdQL61eGhWRthF0xRrT02BCOVJ1p5Ejg5AXfnESTWoKPJ7v/sCkNUtB9g==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
@@ -468,17 +667,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.33.tgz",
-      "integrity": "sha512-6pGQnEdSeRvBViTQh/FwaRKB38a3Th+W2mVxuvqAd2Z1Ayo3e6eJ5QqJoZwEMwR6xoxkl3wz3qAfiB1xRhMC+w==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.28",
-        "@aws-sdk/credential-provider-http": "^3.972.30",
-        "@aws-sdk/credential-provider-ini": "^3.972.32",
-        "@aws-sdk/credential-provider-process": "^3.972.28",
-        "@aws-sdk/credential-provider-sso": "^3.972.32",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.32",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -491,12 +690,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.28.tgz",
-      "integrity": "sha512-CRAlD8u6oNBhjnX/3ekVGocarD+lFmEn/qeDzytgIdmwrmwMJGFPqS9lGwEfhOTihZKrQ0xSp3z6paX+iXJJhA==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -508,14 +707,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.32.tgz",
-      "integrity": "sha512-whhmQghRYOt9mJxFyVMhX7eB8n0oA25OCvqoR7dzFAZjmioCkf7WVB22Bc6llM5cFpBXFX7s4Jv+xVq32VPGWg==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/nested-clients": "^3.997.0",
-        "@aws-sdk/token-providers": "3.1033.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -527,17 +726,75 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.32.tgz",
-      "integrity": "sha512-Z0Y0LDaqyQDznlmr9gv6n4+eWKKWNgmi9j5L6RENr6wyOCguhO8FRPmqDbVLSw0DPdMqICKnA3PurJiS8bD6Cw==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
         "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
+      "integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
+      "integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.14.tgz",
+      "integrity": "sha512-mhTO3amGzYv/DQNbbqZo6UkHquBHlEEVRZwXmjeRqLmy1l9z3xCiFzglPL7n9JpVc2DZc9kjaraAn3JQrueZbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/crc64-nvme": "^3.972.7",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -552,6 +809,20 @@
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
         "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -589,24 +860,39 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.31.tgz",
-      "integrity": "sha512-5hS08Fp0Rm+59uGCmkWhZmveXiA7OUV7Wa+IARejdzf9JTZ1qAVeIOE9JoBpsLPvUgEjmsGNHBuFbtGmYyqiqQ==",
+    "node_modules/@aws-sdk/middleware-sdk-api-gateway": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-api-gateway/-/middleware-sdk-api-gateway-3.972.10.tgz",
+      "integrity": "sha512-CeiwtgS4wvq5KQHjXUJ3bxacBkuu3jy3jGkr8d3lFbQ67E53AdLuxD2ZFh2C3fCykjRXSPC504ThyC/PTtaOSA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.15",
+        "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -614,19 +900,33 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.32.tgz",
-      "integrity": "sha512-HQ0x9DDKqLZOGhDiL2eicYXXkYT5dogE4mw0lAfHCpJ6t7MM0PNIsJl2TZzWKU9SpBzOMXHRa7K6ZLKUJu1y0w==",
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.7",
-        "@smithy/core": "^3.23.15",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-retry": "^4.3.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -634,48 +934,48 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.0.tgz",
-      "integrity": "sha512-4bI5GHjUiY5R8N6PtchpG6tW2Dl8I2IcZNg3JwqwxHRXjfvQlPoo4VMknG4qkd5W0t3Y20rQ6C7pSR561YG5JQ==",
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.32",
-        "@aws-sdk/region-config-resolver": "^3.972.12",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.19",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.18",
-        "@smithy/config-resolver": "^4.4.16",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/hash-node": "^4.2.14",
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.30",
-        "@smithy/middleware-retry": "^4.5.3",
-        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.47",
-        "@smithy/util-defaults-mode-node": "^4.2.52",
-        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -684,13 +984,13 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.12.tgz",
-      "integrity": "sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/config-resolver": "^4.4.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
@@ -700,12 +1000,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.19.tgz",
-      "integrity": "sha512-7Sy8+GhfwUi06NQNLplxuJuXMKJURDsNQfK8yTW6E9wN2J1B+8S5dWZG7vg3InvPPhaXqkcYTr8pzeE+dLjMbQ==",
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.31",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
@@ -717,13 +1017,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1033.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1033.0.tgz",
-      "integrity": "sha512-/TsXhqjyRAFb0xVgmbFAha3cJfZdWjnyn6ohJ3AB4E3peLgxNcmKfYr45hruHymyJAydiHoXC3N1a8qgl41cog==",
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -760,15 +1060,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.7.tgz",
-      "integrity": "sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
         "@smithy/types": "^4.14.1",
         "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -799,12 +1099,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.18.tgz",
-      "integrity": "sha512-Nh4YvAL0Mzv5jBvzXLFL0tLf7WPrRMnYZQ5jlFuyS0xiVJQsObMUKAkbYjmt/e04wpQqUaa+Is7k+mBr89A9yA==",
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.32",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
@@ -824,13 +1124,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
-      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@nodable/entities": "2.1.0",
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.5.8",
+        "fast-xml-parser": "5.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1287,6 +1588,43 @@
         "node": ">=18"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/config-resolver": {
       "version": "4.4.17",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
@@ -1305,9 +1643,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.16",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
-      "integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -1316,7 +1654,7 @@
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.24",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -1427,6 +1765,21 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.15.tgz",
+      "integrity": "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/hash-node": {
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
@@ -1435,6 +1788,20 @@
       "dependencies": {
         "@smithy/types": "^4.14.1",
         "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.14.tgz",
+      "integrity": "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -1466,6 +1833,20 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
+      "integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/middleware-content-length": {
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
@@ -1481,13 +1862,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.31",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.31.tgz",
-      "integrity": "sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.16",
-        "@smithy/middleware-serde": "^4.2.19",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
         "@smithy/types": "^4.14.1",
@@ -1500,19 +1881,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.4.tgz",
-      "integrity": "sha512-/z7nIFK+ZRW3Ie/l3NEVGdy34LvmEOzBrtBAvgWZ/4PrKX0xP3kWm8pkfcwUk523SqxZhdbQP9JSXgjF77Uhpw==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.16",
+        "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/service-error-classification": "^4.3.0",
-        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.3",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -1521,12 +1902,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.19",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.19.tgz",
-      "integrity": "sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.16",
+        "@smithy/core": "^3.23.17",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
@@ -1564,9 +1945,9 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.0.tgz",
-      "integrity": "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -1632,9 +2013,9 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
-      "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1"
@@ -1676,17 +2057,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.12.tgz",
-      "integrity": "sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ==",
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.16",
-        "@smithy/middleware-endpoint": "^4.4.31",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.24",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1778,13 +2159,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.48",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.48.tgz",
-      "integrity": "sha512-hxVRVPYaRDWa6YQdse1aWX1qrksmLsvNyGBKdc32q4jFzSjxYVNWfstknAfR228TnzS4tzgswXRuYIbhXBuXFQ==",
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1793,16 +2174,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.53",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.53.tgz",
-      "integrity": "sha512-ybgCk+9JdBq8pYC8Y6U5fjyS8e4sboyAShetxPNL0rRBtaVl56GSFAxsolVBIea1tXR4LPIzL8i6xqmcf0+DCQ==",
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1850,12 +2231,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.3.tgz",
-      "integrity": "sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.6.tgz",
+      "integrity": "sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/service-error-classification": "^4.3.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1864,13 +2245,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.24",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.24.tgz",
-      "integrity": "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg==",
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.0",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
@@ -1907,9 +2288,9 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.16",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
-      "integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
+      "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -1939,6 +2320,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.161",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
+      "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.17",
@@ -2032,9 +2420,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -2043,9 +2431,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2767,6 +3156,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.7",
+    "@types/aws-lambda": "^8.10.145",
     "@types/node": "^22.15.3",
     "@types/pg": "^8.11.0",
     "esbuild": "^0.24.0",
@@ -14,12 +15,15 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "@aws-sdk/client-api-gateway": "^3.1041.0",
     "@aws-sdk/client-cloudformation": "^3.908.0",
     "@aws-sdk/client-iam": "^3.908.0",
     "@aws-sdk/client-lambda": "^3.908.0",
+    "@aws-sdk/client-s3": "^3.908.0",
     "@aws-sdk/client-secrets-manager": "^3.908.0",
     "adm-zip": "^0.5.16",
-    "pg": "^8.13.0"
+    "pg": "^8.13.0",
+    "zod": "^3.23.8"
   },
   "scripts": {
     "iac": "node ./node_modules/tsx/dist/cli.mjs infra/scripts/deploy.ts",
@@ -34,6 +38,8 @@
     "destroy:apigw:staging": "npm run iac:apigw -- --action destroy --env staging",
     "migrate": "node ./node_modules/tsx/dist/cli.mjs infra/scripts/migrate.ts",
     "migrate:dev": "npm run migrate -- --env dev",
-    "migrate:staging": "npm run migrate -- --env staging"
+    "migrate:staging": "npm run migrate -- --env staging",
+    "deploy:vault-crud": "node ./node_modules/tsx/dist/cli.mjs infra/scripts/deploy-vault-crud.ts --env dev",
+    "deploy:vault-crud:staging": "node ./node_modules/tsx/dist/cli.mjs infra/scripts/deploy-vault-crud.ts --env staging"
   }
 }


### PR DESCRIPTION
Closes #8

## Summary

Ships the API-2 vault-crud Lambda end-to-end: 5 endpoints behind the Cognito authorizer, hybrid VPC networking so the Lambda can actually reach Secrets Manager + RDS from a private subnet, and a deploy script that bundles + uploads + patches the API Gateway stack in one command.

Smoke-tested against `dev` (account `465443875827`) — full chain works: auth → APIGW AWS_PROXY → Lambda → VPC interface endpoint → Secrets Manager → KMS decrypt → pg.Pool → RDS → response.

## What this ships

### 3 new CloudFormation stacks

| Stack | Template | Purpose |
|---|---|---|
| `network-endpoints` | `infra/cloudformation/network-endpoints.yml` | Secrets Manager + CloudWatch Logs VPC interface endpoints, single-AZ in private-subnet-a |
| `lambda-artifacts` | `infra/cloudformation/lambda-artifacts.yml` | S3 bucket for Lambda zips, 7-day lifecycle, AES256, public access blocked |
| `vault-crud-lambda` | `infra/cloudformation/vault-crud-lambda.yml` | Lambda + IAM role + log group (14-day retention) + APIGW invoke permission |

### Lambda code

- `infra/lambda/shared/` — auth (extract Cognito sub), errors (`ApiError` + `ErrorCode` enum), response (CORS-aware `ok`/`created`/`error`/`handleError`), db (module-scope `pg.Pool` + cached secret fetch + `ensureUser`), types
- `infra/lambda/vault-crud/` — `index.ts` router + 5 handlers (`list`, `create`, `get`, `update`, `delete`)

Per acceptance criteria: parameterized SQL throughout, ownership scoping via `WHERE id = $1 AND user_id = $2` on every per-entry query (404 not 403 for cross-tenant — doesn't leak existence), `tags` array filtering with AND containment via `tags @> $N`, `COUNT(*) OVER ()` window function for paginated total in a single query, `index_status` reset to `'pending'` only when content changes, CASCADE delete handles `vault_chunks` / `vault_chunk_parents`.

### API Gateway integration

`api-gateway.yml` adds a `VaultCrudLambdaArn` parameter (default `""`) and a `VaultCrudWired` condition. The 5 `/vault/entries` methods use `!If` to switch between `AWS_PROXY` (when wired) and the original MOCK 501 fallback (when not). The template stays standalone-deployable.

`deploy-api-gateway.ts` was patched to detect an existing `VaultCrudLambdaArn` parameter and pass `UsePreviousValue: true`, so plain `npm run deploy:apigw` doesn't reset the integration.

### Deploy script

`infra/scripts/deploy-vault-crud.ts` is a 5-phase orchestrator:

1. Resolve `lambda-artifacts` bucket name from CFN exports
2. Bundle `infra/lambda/vault-crud/index.ts` with esbuild + adm-zip
3. Upload `vault-crud/{sha256}.zip` to S3 (content-hashed key so CFN sees real code changes)
4. Create/update `vault-crud-lambda` stack with the new `ArtifactsKey`
5. Patch `api-gateway` stack with the Lambda ARN, then **explicitly create a new `Deployment`** so the live `prod` stage picks up the new method integrations (CFN updates the Method/Integration resources but doesn't trigger a stage redeploy on its own — discovered during smoke testing, see notes below)

## Cost decision: VPC interface endpoints over NAT

Picked single-AZ VPC interface endpoints (~$14/mo: $7.20/endpoint × 2) instead of a NAT Gateway (~$30/mo) or dual-AZ endpoints (~$28/mo). The single-AZ choice forces the vault-crud Lambda into `private-subnet-a` only, which is acceptable since the project is course-bounded — fault-tolerance in dev isn't worth doubling the bill.

## Acceptance criteria (from #8)

- [x] All 5 CRUD operations work correctly
- [x] Entries scoped to authenticated user (`WHERE user_id = $N` on every query)
- [x] Project/global scoping works (`scope=project` / `global` / `all` in list query)
- [x] Tag filtering with AND logic (`tags @> $N` containment)
- [x] Pagination with correct totals (`COUNT(*) OVER ()` window function)
- [x] Cascade delete on chunks (FK + `ON DELETE CASCADE` from INFRA-5 schema)
- [ ] S3 cleanup on delete with file — **deferred to API-3.** The `delete` handler returns the entry's `s3_key` for the future cleanup step; TODO comment in code.
- [x] DB credentials cached at cold start (module-scope singleton)
- [x] User ID from Cognito JWT claims (`event.requestContext.authorizer.claims.sub`)
- [x] Parameterized queries throughout

## Verification

Deployed against dev and exercised every endpoint with a real Cognito JWT:

```
=== 4a. POST /vault/entries === [HTTP 201]
{"id":"ee9d790b-...","title":"Smoke test entry","content":"hello",
 "entry_type":"note","tags":["smoke","test"],"index_status":"pending",...}

=== 4b. GET /vault/entries === [HTTP 200]
{"entries":[{...}],"total":1,"page":1}

=== 4c. GET /vault/entries/{id} === [HTTP 200]
{"id":"ee9d790b-...", ...}

=== 4d. PUT /vault/entries/{id} === [HTTP 200]
{..., "title":"Smoke test entry (updated)",
 "updated_at":"2026-05-01T22:53:10.384Z"}   # bumped from :09.829Z

=== 4e. DELETE /vault/entries/{id} === [HTTP 200]
{"deleted":true,"id":"ee9d790b-..."}
```

A fixture user `smoketest@solo-vault.dev` and its row in `users` are left in dev for repeat smoke tests.

## Notes for reviewers (bugs found during smoke)

1. **Lambda role needed `kms:Decrypt` on the RDS CMK.** First invoke after the network was wired errored with `AccessDeniedException: Access to KMS is not allowed`. The `db-credentials` secret is encrypted with the customer-managed `RdsEncryptionKey` (from secrets stack), so `secretsmanager:GetSecretValue` alone isn't enough — you also need decrypt on the imported `${prefix}-rds-cmk-arn`. Fixed in `vault-crud-lambda.yml` IAM policy.

2. **API Gateway needs an explicit stage redeploy after method changes.** CFN happily updates `AWS::ApiGateway::Method` / `AWS::ApiGateway::Integration` resources but the live stage keeps serving the previous `Deployment` snapshot until something explicitly creates a new one. First smoke test still hit MOCK 501 even though the integration was already AWS_PROXY at the resource level. The deploy script now calls `apigateway:CreateDeployment` after the CFN patch.

3. **zod error messages don't include the field path** — got `"Required"` instead of `"entry_type: Required"` when the smoke test sent `type` instead of `entry_type`. Mildly annoying but not gating; can be polished by passing `parsed.error.issues[0].path` into the message. Not in this PR.

## Test plan
- [x] All 5 endpoints return expected status codes against dev
- [x] Lambda cold start fetches credentials via VPC interface endpoint (verified — first invoke logged Init Duration)
- [x] CASCADE delete works (no orphaned chunks)
- [x] `npm run deploy:vault-crud` is idempotent (re-run produced "No changes for api-gateway" + clean redeploy)
- [ ] Staging deployment — not done in this PR; same `make deploy` sequence with `STAGE=staging` should work, will run before any staging smoke tests
- [ ] Cross-tenant 404 test (second user attempting another's entry) — not in this smoke; relies on the `WHERE user_id = $N` clause that's present on every query
